### PR TITLE
feat: Actuator 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = false
+insert_final_newline = true
+max_line_length = 200
+tab_width = 4
+ij_continuation_indent_size = 8
+ij_smart_tabs = false
+ij_visual_guides = 200
+ij_wrap_on_typing = false
+ij_formatter_off_tag = @formatter:off
+ij_formatter_on_tag = @formatter:on
+ij_formatter_tags_enabled = false
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.yml,*.yaml,*.json}]
+indent_size = 2
+
+[{*.kt,*.kts}]
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = false
+ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
+ij_kotlin_name_count_to_use_star_import = 99
+ij_kotlin_name_count_to_use_star_import_for_members = 99

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,11 @@
 ### Application version ###
 applicationVersion=0.0.1
-
 ### Project configs ###
 projectGroup=com.mashup
-
 ### Project dependency versions ###
 kotlinVersion=1.8.21
-
 ### Spring dependency versions ###
 springBootVersion=3.1.0
 springDependencyManagementVersion=1.1.0
-
 ### Jib version for containerization
 jibVersion=3.3.2

--- a/http/actuator.http
+++ b/http/actuator.http
@@ -1,0 +1,14 @@
+### All actautor
+GET {{moit-api-actuator}}/am-i-alive
+
+### Info
+GET {{moit-api-actuator}}/am-i-alive/info
+
+### Health
+GET {{moit-api-actuator}}/am-i-alive/health
+
+### Metrics
+GET {{moit-api-actuator}}/am-i-alive/metrics
+
+### Prometheus
+GET {{moit-api-actuator}}/am-i-alive/prometheus

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,5 +1,6 @@
 {
   "local": {
-    "moit-api": "http://localhost:8080"
+	"moit-api": "http://localhost:8080",
+	"moit-api-actuator": "http://localhost:8077"
   }
 }

--- a/http/sample.http
+++ b/http/sample.http
@@ -3,7 +3,7 @@ POST {{moit-api}}/api/v1/samples
 Content-Type: application/json
 
 {
-  "name": "test1"
+    "name": "test1"
 }
 
 ### Sample 조회

--- a/moit-api/build.gradle.kts
+++ b/moit-api/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     implementation(project(":moit-common"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 }
 
 configure<JibExtension> {

--- a/moit-api/src/main/kotlin/com/mashup/moit/sample/controller/SampleController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/sample/controller/SampleController.kt
@@ -4,7 +4,12 @@ import com.mashup.moit.common.ApiResponse
 import com.mashup.moit.sample.controller.dto.SampleCreateRequest
 import com.mashup.moit.sample.controller.dto.SampleResponse
 import com.mashup.moit.sample.facade.SampleFacade
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RequestMapping("/api/v1/samples")
 @RestController

--- a/moit-api/src/main/resources/application.yml
+++ b/moit-api/src/main/resources/application.yml
@@ -4,3 +4,27 @@ spring:
   config:
     import:
       - application-domain.yml
+
+# Actuator 정보
+management:
+  endpoints:
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: info, health, metrics, prometheus
+      base-path: "/am-i-alive"
+  endpoint:
+    info:
+      enabled: true
+    health:
+      enabled: true
+      show-details : always
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
+  server:
+    port: 8077

--- a/moit-common/src/main/kotlin/com/mashup/moit/common/exception/MoitException.kt
+++ b/moit-common/src/main/kotlin/com/mashup/moit/common/exception/MoitException.kt
@@ -1,7 +1,5 @@
 package com.mashup.moit.common.exception
 
-import java.lang.RuntimeException
-
 class MoitException(
     val errorCode: String,
     val httpStatusCode: Int,

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/common/BaseEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/common/BaseEntity.kt
@@ -1,6 +1,10 @@
 package com.mashup.moit.domain.common
 
-import jakarta.persistence.*
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener


### PR DESCRIPTION
서버 상태 및 메트릭 등 확인하기 위해 API 모듈에 Actautor를 추가했습니다.

info/health/metrics/prometheus를 제외한 actuator endpoint는 비활성화 했습니다. ([참고 글](https://techblog.woowahan.com/9232/))