### PR TITLE
chore: 컨테이너 배포를 위한 jib 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("plugin.jpa") apply false
     id("org.springframework.boot") apply false
     id("io.spring.dependency-management") apply false
+    id("com.google.cloud.tools.jib") apply false
 }
 
 java.sourceCompatibility = JavaVersion.VERSION_17

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,6 @@ kotlinVersion=1.8.21
 ### Spring dependency versions ###
 springBootVersion=3.1.0
 springDependencyManagementVersion=1.1.0
+
+### Jib version for containerization
+jibVersion=3.3.2

--- a/moit-api/build.gradle.kts
+++ b/moit-api/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.google.cloud.tools.jib.gradle.JibExtension
+
 tasks.getByName("bootJar") {
     enabled = true
 }
@@ -6,9 +8,51 @@ tasks.getByName("jar") {
     enabled = false
 }
 
+apply(plugin = "com.google.cloud.tools.jib")
+
 dependencies {
     implementation(project(":moit-domain"))
     implementation(project(":moit-common"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+}
+
+configure<JibExtension> {
+    val registryUsername = System.getenv("DOCKERHUB_USERNAME")
+    val (activeProfile, containerImageName) = getProfileAndImageName(registryUsername)
+
+    from {
+        image = "eclipse-temurin:17-jre"
+    }
+
+    to {
+        image = containerImageName
+        tags = setOf("$version", "latest")
+        auth {
+            username = registryUsername
+            password = System.getenv("DOCKERHUB_PASSWORD")
+        }
+    }
+
+    container {
+        // TODO: 서버 스펙에 따라 Xmx/Xms, Initial/Min/MaxRAMFraction 설정
+        jvmFlags = listOf(
+            "-server",
+            "-XX:+UseContainerSupport",
+            "-XX:+UseStringDeduplication",
+            "-Dserver.port=8080",
+            "-Dfile.encoding=UTF-8",
+            "-Djava.awt.headless=true",
+            "-Dspring.profiles.active=${activeProfile}",
+        )
+        ports = listOf("8080")
+    }
+}
+
+fun getProfileAndImageName(registryUsername: String?): Array<String> {
+    val containerImageName = "${registryUsername}/${project.name}"
+    if (project.hasProperty("release")) {
+        return arrayOf("release", containerImageName)
+    }
+    return arrayOf("dev", "$containerImageName-dev")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ pluginManagement {
     val kotlinVersion: String by settings
     val springBootVersion: String by settings
     val springDependencyManagementVersion: String by settings
+    val jibVersion: String by settings
 
     resolutionStrategy {
         eachPlugin {
@@ -19,6 +20,7 @@ pluginManagement {
                 "org.jetbrains.kotlin.plugin.jpa" -> useVersion(kotlinVersion)
                 "org.springframework.boot" -> useVersion(springBootVersion)
                 "io.spring.dependency-management" -> useVersion(springDependencyManagementVersion)
+                "com.google.cloud.tools.jib" -> useVersion(jibVersion)
             }
         }
     }


### PR DESCRIPTION
컨테이너 배포를 위한 [jib](https://github.com/GoogleContainerTools/jib) 설정을 추가했습니다.

- Dockerhub를 기준으로 설정했습니다. 돈도 없으니, 무료로 가시죠. (추후 필요하면 변경!)
  - 계정은 제 계정으로 테스트했는데, 저희 구글 계정으로 하나 만들어서 활용하면 될 듯 합니다.
- 기본적으로 필요한 jvm options 추가해봤습니다. 필요없거나, 필요할 것 같은거 있으시면 리뷰 부탁드립니다.
- profile에 따라 active profile, container name이 설정되도록 구성했습니다.
  - 일단 `dev`, `release` 만 사용할 것을 고려해서 구성했습니다. 
  - build용이다보니 함수 그냥 러프하게 작성했는데 이상하면 리뷰주세요.
    - `release`: `./gradlew :moit-api:jib -Prelease`
    - `dev`: Profile 추가 안한 상태로 jib 빌드하면 기본적으로 dev 설정. ex)`./gradlew :moit-api:jib`