### PR TITLE
delete : docker cache in cd

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -40,8 +40,6 @@ jobs:
           context: .
           push: true
           tags: electroncorps/moit-api:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           
       - run: |
           cd deploy && zip -r deploy.zip .


### PR DESCRIPTION
```
Error: buildx failed with: ERROR: cache export feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
```

cd 해당 에러로 인해 docker cache 사용 제거합니다