### PR TITLE
feat: Study 출석 결과 페이지 API - 출석 멤버 상태 조회 API (mock)

### DIFF
--- a/moit-api/src/main/kotlin/com/mashup/moit/study/controller/StudyController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/controller/StudyController.kt
@@ -3,6 +3,7 @@ package com.mashup.moit.study.controller
 import com.mashup.moit.common.MoitApiResponse
 import com.mashup.moit.study.controller.dto.StudyAttendanceKeywordResponse
 import com.mashup.moit.study.controller.dto.StudyFirstAttendanceResponse
+import com.mashup.moit.study.controller.dto.StudyUserAttendanceStatusResponse
 import com.mashup.moit.study.facade.StudyFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -28,6 +29,18 @@ class StudyController(
     @GetMapping("/{studyId}/attendance/is-first")
     fun isFirstAttendance(@PathVariable studyId: Long): MoitApiResponse<StudyFirstAttendanceResponse> {
         return MoitApiResponse.success(StudyFirstAttendanceResponse.sample())
+    }
+
+    @Operation(summary = "Study 유저 출석상태 조회 API", description = "Study 참석자 출석 상태 조회. 출석/지각 완료(결과) 페이지에서 사용됨.")
+    @GetMapping("/{studyId}/attendance/status")
+    fun getUserAttendanceStatus(@PathVariable studyId: Long): MoitApiResponse<List<StudyUserAttendanceStatusResponse>> {
+        return MoitApiResponse.success(
+            listOf(
+                StudyUserAttendanceStatusResponse.sample(),
+                StudyUserAttendanceStatusResponse.sample(),
+                StudyUserAttendanceStatusResponse.sample()
+            )
+        )
     }
 
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
@@ -1,6 +1,8 @@
 package com.mashup.moit.study.controller.dto
 
+import com.mashup.moit.domain.attendance.AttendanceStatus
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
 
 @Schema(description = "Study 출석 키워드 조회 응답")
 data class StudyAttendanceKeywordResponse(
@@ -22,3 +24,21 @@ data class StudyFirstAttendanceResponse(
     }
 }
 
+@Schema(description = "Study 유저 출석상태 응답")
+data class StudyUserAttendanceStatusResponse(
+    val userId: Long,
+    val nickname: String,
+    val profileImage: Int,
+    val attendanceStatus: AttendanceStatus,
+    val attendanceAt: LocalDateTime
+) {
+    companion object {
+        fun sample() = StudyUserAttendanceStatusResponse(
+            1L,
+            "나는 부자가 될테야",
+            2,
+            AttendanceStatus.ATTENDANCE,
+            LocalDateTime.now()
+        )
+    }
+}

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
@@ -2,7 +2,7 @@ package com.mashup.moit.study.controller.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "study 출석 키워드 조회 응답")
+@Schema(description = "Study 출석 키워드 조회 응답")
 data class StudyAttendanceKeywordResponse(
     @Schema(description = "Study 출석 키워드")
     val attendanceKeyword: String,
@@ -12,7 +12,7 @@ data class StudyAttendanceKeywordResponse(
     }
 }
 
-@Schema(description = "study 첫 출석자 존재 유무 응답")
+@Schema(description = "Study 첫 출석자 존재 유무 응답")
 data class StudyFirstAttendanceResponse(
     @Schema(description = "Study 첫 출석자 존재 유무")
     val isFirstAttendance: Boolean,

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
@@ -30,7 +30,7 @@ data class StudyUserAttendanceStatusResponse(
     val nickname: String,
     val profileImage: Int,
     val attendanceStatus: AttendanceStatus,
-    val attendanceAt: LocalDateTime
+    val attendanceAt: LocalDateTime?
 ) {
     companion object {
         fun sample() = StudyUserAttendanceStatusResponse(


### PR DESCRIPTION
#38 

---

ref) [2) 스터디 출석 결과 페이지 API - 출석 멤버 상태 조회](https://www.notion.so/2-API-19b5b1c9672f4823b047f262f498f1a4?pvs=4)