### PR TITLE
Add Study Details API to StudyController

### DIFF
--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,6 +1,6 @@
 {
   "local": {
-	"moit-api": "http://localhost:9090",
+	"moit-api": "http://localhost:8080",
 	"moit-api-actuator": "http://localhost:8077",
     "moitId" : "1",
     "studyId" : "1"

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,6 +1,6 @@
 {
   "local": {
-	"moit-api": "http://localhost:8080",
+	"moit-api": "http://localhost:9090",
 	"moit-api-actuator": "http://localhost:8077",
     "moitId" : "1",
     "studyId" : "1"

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/controller/StudyController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/controller/StudyController.kt
@@ -3,6 +3,7 @@ package com.mashup.moit.study.controller
 import com.mashup.moit.common.MoitApiResponse
 import com.mashup.moit.study.controller.dto.StudyAttendanceCodeRequest
 import com.mashup.moit.study.controller.dto.StudyAttendanceKeywordResponse
+import com.mashup.moit.study.controller.dto.StudyDetailsResponse
 import com.mashup.moit.study.controller.dto.StudyFirstAttendanceResponse
 import com.mashup.moit.study.controller.dto.StudyUserAttendanceStatusResponse
 import com.mashup.moit.study.facade.StudyFacade
@@ -22,6 +23,13 @@ import org.springframework.web.bind.annotation.RestController
 class StudyController(
     private val studyFacade: StudyFacade
 ) {
+
+    @Operation(summary = "Study Detail API", description = "Study 상세 조회")
+    @GetMapping("/{studyId}")
+    fun getDetail(@PathVariable studyId: Long): MoitApiResponse<StudyDetailsResponse> {
+        return MoitApiResponse.success(StudyDetailsResponse.sample())
+    }
+
     @Operation(summary = "Study Keyword API", description = "study 키워드 조회")
     @GetMapping("/{studyId}/attendance/keyword")
     fun getAttendanceKeyword(@PathVariable studyId: Long): MoitApiResponse<StudyAttendanceKeywordResponse> {

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
@@ -1,7 +1,6 @@
 package com.mashup.moit.study.controller.dto
 
 import com.mashup.moit.domain.attendance.AttendanceStatus
-import com.mashup.moit.moit.controller.dto.MoitDetailsResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
@@ -9,8 +8,8 @@ import java.time.LocalDateTime
 
 @Schema(description = "Study 상세 조회 응답")
 data class StudyDetailsResponse(
-    @Schema(description = "Study가 속한 Moit 정보")
-    val moit: MoitDetailsResponse,
+    @Schema(description = "Study가 속한 Moit 이름")
+    val moitName: String,
     @Schema(description = "Study 회차")
     val order: Int,
     @Schema(description = "Study 시작 날짜 및 시간")
@@ -24,18 +23,18 @@ data class StudyDetailsResponse(
     @Schema(description = "Study 결석 날짜 및 시간")
     val absenceAt: LocalDateTime,
     @Schema(description = "첫 번째 출석한 유저 아이디")
-    val firstAttendanceUserId: Long? = null
+    val firstAttendanceUserNickname: String? = null
 ) {
     companion object {
         fun sample(): StudyDetailsResponse = StudyDetailsResponse(
-            moit = MoitDetailsResponse.sample(),
+            moitName = "전자군단",
             order = 1,
             startAt = LocalDateTime.of(2023, 6, 15, 16, 0),
             endAt = LocalDateTime.of(2023, 6, 15, 19, 0),
             remindAt = LocalDateTime.of(2023, 6, 15, 15, 30),
             lateAt = LocalDateTime.of(2023, 6, 15, 16, 30),
             absenceAt = LocalDateTime.of(2023, 6, 15, 17, 0),
-            firstAttendanceUserId = null
+            firstAttendanceUserNickname = null
         )
     }
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
@@ -1,25 +1,50 @@
 package com.mashup.moit.study.controller.dto
 
 import com.mashup.moit.domain.attendance.AttendanceStatus
+import com.mashup.moit.moit.controller.dto.MoitDetailsResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
 
+@Schema(description = "Study 상세 조회 응답")
+data class StudyDetailsResponse(
+    @Schema(description = "Study가 속한 Moit 정보")
+    val moit: MoitDetailsResponse,
+    @Schema(description = "Study 회차")
+    val order: Int,
+    @Schema(description = "Study 시작 날짜 및 시간")
+    val startAt: LocalDateTime,
+    @Schema(description = "Study 끝나는 날짜 및 시간")
+    val endAt: LocalDateTime,
+    @Schema(description = "Study 리마인드 날짜 및 시간")
+    val remindAt: LocalDateTime,
+    @Schema(description = "Study 지각 날짜 및 시간")
+    val lateAt: LocalDateTime,
+    @Schema(description = "Study 결석 날짜 및 시간")
+    val absenceAt: LocalDateTime,
+    @Schema(description = "첫 번째 출석한 유저 아이디")
+    val firstAttendanceUserId: Long? = null
+) {
+    companion object {
+        fun sample(): StudyDetailsResponse = StudyDetailsResponse(
+            moit = MoitDetailsResponse.sample(),
+            order = 1,
+            startAt = LocalDateTime.of(2023, 6, 15, 16, 0),
+            endAt = LocalDateTime.of(2023, 6, 15, 19, 0),
+            remindAt = LocalDateTime.of(2023, 6, 15, 15, 30),
+            lateAt = LocalDateTime.of(2023, 6, 15, 16, 30),
+            absenceAt = LocalDateTime.of(2023, 6, 15, 17, 0),
+            firstAttendanceUserId = null
+        )
+    }
+}
+
 @Schema(description = "Study 참석 코드 요청")
 data class StudyAttendanceCodeRequest(
-<<<<<<< HEAD
     @Schema(description = "Study 참석 코드")
     @field:NotBlank
     @Size(min = 4, max = 4)
-=======
-    @Schema(description = "유저 id")
-    val userId: Long,
-
-    @Schema(description = "Study 참석 코드")
-    @field:NotBlank
-    @Size(min = 8, max = 8)
->>>>>>> 2a0e340 (Add registerAttendnaceKeyword API to StudyController)
     val attendanceKeyword: String
 )
 

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/controller/dto/StudyDto.kt
@@ -8,9 +8,18 @@ import java.time.LocalDateTime
 
 @Schema(description = "Study 참석 코드 요청")
 data class StudyAttendanceCodeRequest(
+<<<<<<< HEAD
     @Schema(description = "Study 참석 코드")
     @field:NotBlank
     @Size(min = 4, max = 4)
+=======
+    @Schema(description = "유저 id")
+    val userId: Long,
+
+    @Schema(description = "Study 참석 코드")
+    @field:NotBlank
+    @Size(min = 8, max = 8)
+>>>>>>> 2a0e340 (Add registerAttendnaceKeyword API to StudyController)
     val attendanceKeyword: String
 )
 


### PR DESCRIPTION
스터디 상세 조회 (스상조) Mock Server 만들었습니다.

우선 Moit 상세 정보는 원래 있던 MoitDetailsResponse를 넣어줬는데 불필요하게 크다 생각하면 말씀해주세요. 저는 괜찮은 사이즈라 생각했습니다

이 브랜치는 #47 머지 이후 머지할 예정입니다.