### PR TITLE
feat: add validation join moit after startDate

### DIFF
--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitEntity.kt
@@ -1,10 +1,13 @@
 package com.mashup.moit.domain.moit
 
+import com.mashup.moit.common.exception.MoitException
+import com.mashup.moit.common.exception.MoitExceptionType
 import com.mashup.moit.domain.common.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.LocalDate
 
 @Table(name = "moit")
 @Entity
@@ -55,4 +58,14 @@ class MoitEntity(
             notificationRemindOption = notificationPolicy.remindOption,
             notificationRemindLevel = notificationPolicy.remindLevel
         )
+
+     fun validateDateForJoin(): MoitEntity {
+        if (isEnd) {
+            throw MoitException.of(MoitExceptionType.INVALID_ACCESS, "종료된 Moit 입니다")
+        }
+        if (schedulePolicy.startDate.isBefore(LocalDate.now())) {
+            throw MoitException.of(MoitExceptionType.INVALID_ACCESS, "이미 시작된 Moit 입니다")
+        }
+        return this
+    }
 } 

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitEntity.kt
@@ -59,13 +59,12 @@ class MoitEntity(
             notificationRemindLevel = notificationPolicy.remindLevel
         )
 
-     fun validateDateForJoin(): MoitEntity {
+    fun validateDateForJoin() {
         if (isEnd) {
             throw MoitException.of(MoitExceptionType.INVALID_ACCESS, "종료된 Moit 입니다")
         }
         if (schedulePolicy.startDate.isBefore(LocalDate.now())) {
             throw MoitException.of(MoitExceptionType.INVALID_ACCESS, "이미 시작된 Moit 입니다")
         }
-        return this
     }
 } 

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitService.kt
@@ -70,12 +70,8 @@ class MoitService(
     }
 
     fun getMoitByInvitationCode(invitationCode: String): Moit {
-        val moit = moitRepository.findByInvitationCode(invitationCode.uppercase(Locale.getDefault()))
-            ?: throw MoitException.of(MoitExceptionType.NOT_EXIST)
-
-        if (moit.isEnd) throw MoitException.of(MoitExceptionType.INVALID_ACCESS, "종료된 Moit 입니다")
-
-        return moit.toDomain()
+        return moitRepository.findByInvitationCode(invitationCode.uppercase(Locale.getDefault()))
+            ?.validateDateForJoin()?.toDomain() ?: throw MoitException.of(MoitExceptionType.NOT_EXIST)
     }
 
     fun getMoitById(moitId: Long): Moit {

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitService.kt
@@ -71,7 +71,8 @@ class MoitService(
 
     fun getMoitByInvitationCode(invitationCode: String): Moit {
         return moitRepository.findByInvitationCode(invitationCode.uppercase(Locale.getDefault()))
-            ?.validateDateForJoin()?.toDomain() ?: throw MoitException.of(MoitExceptionType.NOT_EXIST)
+            ?.also { it.validateDateForJoin() }?.toDomain()
+            ?: throw MoitException.of(MoitExceptionType.NOT_EXIST)
     }
 
     fun getMoitById(moitId: Long): Moit {


### PR DESCRIPTION
ref : https://github.com/mash-up-kr/MOIT-backend/pull/44#discussion_r1231730830

moit 시작되면 invitationCode 비우는 것보단 validation 으로 처리할 수 있을 것 같아서 
member join 시 moit validation 에 시작 시간보다 뒤 늦은 요청인지 확인하는 로직 보강하였습니다. 