### PR TITLE
feat(#58) : add fine list API

### DIFF
--- a/moit-api/src/main/kotlin/com/mashup/moit/fine/controller/FineController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/fine/controller/FineController.kt
@@ -50,6 +50,6 @@ class FineController(
     @Operation(summary = "벌금 리스트 조회 API", description = "벌금 리스트 조회 API")
     @GetMapping
     fun fineList(@PathVariable("moitId") moitId: Long): MoitApiResponse<FineListResponse> {
-        return MoitApiResponse.success(FineListResponse.sample())
+        return MoitApiResponse.success(fineFacade.getFineList(moitId))
     }
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/fine/controller/dto/FineDto.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/fine/controller/dto/FineDto.kt
@@ -1,6 +1,9 @@
 package com.mashup.moit.fine.controller.dto
 
 import com.mashup.moit.domain.attendance.AttendanceStatus
+import com.mashup.moit.domain.fine.Fine
+import com.mashup.moit.domain.study.Study
+import com.mashup.moit.domain.user.User
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
@@ -23,35 +26,7 @@ data class FineListResponse(
     val fineComplete: List<FineResponseForListView>,
 ) {
     companion object {
-        fun sample() = FineListResponse(
-            totalFineAmount = 100000000000,
-            fineNotYet = listOf(
-                FineResponseForListView(
-                    id = 2L,
-                    fineAmount = 50000000000,
-                    userId = 1L,
-                    userName = "박재민",
-                    attendanceStatus = AttendanceStatus.ABSENCE,
-                    studyOrder = 5,
-                    isConfirmed = false,
-                    registerAt = LocalDate.of(2023, 6, 8),
-                    paymentAt = LocalDate.of(2023, 6, 15)
-                )
-            ),
-            fineComplete = listOf(
-                FineResponseForListView(
-                    id = 1L,
-                    fineAmount = 50000000000,
-                    userId = 1L,
-                    userName = "박재민",
-                    attendanceStatus = AttendanceStatus.ABSENCE,
-                    studyOrder = 5,
-                    isConfirmed = true,
-                    registerAt = LocalDate.of(2023, 6, 8),
-                    paymentAt = null
-                )
-            )
-        )
+        fun emptyFineList() = FineListResponse(0, emptyList(), emptyList())
     }
 }
 
@@ -63,16 +38,31 @@ data class FineResponseForListView(
     val fineAmount: Long,
     @Schema(description = "Fine 대상 User id")
     val userId: Long,
-    @Schema(description = "Fine 대상 User 이름")
-    val userName: String,
+    @Schema(description = "Fine 대상 User nickname")
+    val userNickname: String,
     @Schema(description = "Fine 대상 출석 상태 (LATE, ABSENCE)")
     val attendanceStatus: AttendanceStatus,
     @Schema(description = "Fine 대상 스터디 회차")
     val studyOrder: Int,
     @Schema(description = "Fine 납부 인증 유무")
-    val isConfirmed: Boolean,
+    val isApproved: Boolean,
     @Schema(description = "Fine 등록 일자 YYYY-mm-dd")
     val registerAt: LocalDate,
     @Schema(description = "Fine 납부 일자 YYYY-mm-dd")
-    val paymentAt: LocalDate?,
-)
+    val approveAt: LocalDate?,
+) {
+    companion object {
+        fun of(fine: Fine, user: User, study: Study) =
+            FineResponseForListView(
+                id = fine.id,
+                fineAmount = fine.amount,
+                userId = fine.userId,
+                userNickname = user.nickname,
+                attendanceStatus = fine.attendanceStatus,
+                studyOrder = study.order,
+                isApproved = fine.isApproved,
+                registerAt = fine.registerAt.toLocalDate(),
+                approveAt = fine.approvedAt?.toLocalDate()
+            )
+    }
+}

--- a/moit-api/src/main/kotlin/com/mashup/moit/fine/controller/dto/FineDto.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/fine/controller/dto/FineDto.kt
@@ -7,6 +7,7 @@ import com.mashup.moit.domain.user.User
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 
 @Schema(description = "벌금 송금 평가 RequestBody")
@@ -46,10 +47,8 @@ data class FineResponseForListView(
     val studyOrder: Int,
     @Schema(description = "Fine 납부 인증 유무")
     val isApproved: Boolean,
-    @Schema(description = "Fine 등록 일자 YYYY-mm-dd")
-    val registerAt: LocalDate,
     @Schema(description = "Fine 납부 일자 YYYY-mm-dd")
-    val approveAt: LocalDate?,
+    val approveAt: LocalDateTime?,
 ) {
     companion object {
         fun of(fine: Fine, user: User, study: Study) =
@@ -60,9 +59,8 @@ data class FineResponseForListView(
                 userNickname = user.nickname,
                 attendanceStatus = fine.attendanceStatus,
                 studyOrder = study.order,
-                isApproved = fine.isApproved,
-                registerAt = fine.registerAt.toLocalDate(),
-                approveAt = fine.approvedAt?.toLocalDate()
+                isApproved = fine.isApproved, 
+                approveAt = fine.approvedAt
             )
     }
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/fine/facade/FineFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/fine/facade/FineFacade.kt
@@ -20,7 +20,7 @@ class FineFacade(
         }
 
         val fineUserIds = fineList.map { it.userId }.distinct()
-        val fineUsersMap = userService.findUsersByIds(fineUserIds).associateBy { it.id }
+        val fineUsersMap = userService.findUsersById(fineUserIds).associateBy { it.id }
 
         val fineStudyIds = fineList.map { it.studyId }.distinct()
         val fineStudyMap = studyService.findByStudyIds(fineStudyIds).associateBy { it.id }
@@ -29,9 +29,9 @@ class FineFacade(
         val (fineComplete, fineNotYet) = fineList.partition { it.isApproved }
             .let { (approvedFineList, isNotApprovedFineList) ->
                 approvedFineList.map {
-                    FineResponseForListView.of(it, fineUsersMap[it.userId]!!, fineStudyMap[it.studyId]!!)
+                    FineResponseForListView.of(it, fineUsersMap.getValue(it.userId), fineStudyMap.getValue(it.studyId))
                 } to isNotApprovedFineList.map {
-                    FineResponseForListView.of(it, fineUsersMap[it.userId]!!, fineStudyMap[it.studyId]!!)
+                    FineResponseForListView.of(it, fineUsersMap.getValue(it.userId), fineStudyMap.getValue(it.studyId))
                 }
             }
 

--- a/moit-api/src/main/kotlin/com/mashup/moit/fine/facade/FineFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/fine/facade/FineFacade.kt
@@ -1,7 +1,40 @@
 package com.mashup.moit.fine.facade
 
+import com.mashup.moit.domain.fine.FineService
+import com.mashup.moit.domain.study.StudyService
+import com.mashup.moit.domain.user.UserService
+import com.mashup.moit.fine.controller.dto.FineListResponse
+import com.mashup.moit.fine.controller.dto.FineResponseForListView
 import org.springframework.stereotype.Component
 
 @Component
-class FineFacade {
+class FineFacade(
+    private val fineService: FineService,
+    private val studyService: StudyService,
+    private val userService: UserService
+) {
+    fun getFineList(moitId: Long): FineListResponse {
+        val fineList = fineService.getFineListByMoitId(moitId)
+        if (fineList.isEmpty()) {
+            return FineListResponse.emptyFineList()
+        }
+
+        val fineUserIds = fineList.map { it.userId }.distinct()
+        val fineUsersMap = userService.findUsersByIds(fineUserIds).associateBy { it.id }
+
+        val fineStudyIds = fineList.map { it.studyId }.distinct()
+        val fineStudyMap = studyService.findByStudyIds(fineStudyIds).associateBy { it.id }
+
+        val totalFineAmount = fineList.sumOf { it.amount }
+        val (fineComplete, fineNotYet) = fineList.partition { it.isApproved }
+            .let { (approvedFineList, isNotApprovedFineList) ->
+                approvedFineList.map {
+                    FineResponseForListView.of(it, fineUsersMap[it.userId]!!, fineStudyMap[it.studyId]!!)
+                } to isNotApprovedFineList.map {
+                    FineResponseForListView.of(it, fineUsersMap[it.userId]!!, fineStudyMap[it.studyId]!!)
+                }
+            }
+
+        return FineListResponse(totalFineAmount, fineNotYet, fineComplete)
+    }
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/Fine.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/Fine.kt
@@ -1,5 +1,22 @@
 package com.mashup.moit.domain.fine
 
+import com.mashup.moit.domain.attendance.AttendanceStatus
+import java.time.LocalDateTime
+
 enum class FineApproveStatus {
     NEW, IN_PROGRESS, REJECTED, APPROVED;
 }
+
+data class Fine(
+    val id: Long,
+    val moitId: Long,
+    val studyId: Long,
+    val userId: Long,
+    val attendanceStatus: AttendanceStatus,
+    val amount: Long,
+    val isApproved: Boolean,
+    val approveStatus: FineApproveStatus,
+    val approvedAt: LocalDateTime?,
+    val approveImageUrl: String?,
+    val registerAt: LocalDateTime,
+)

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/Fine.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/Fine.kt
@@ -18,5 +18,4 @@ data class Fine(
     val approveStatus: FineApproveStatus,
     val approvedAt: LocalDateTime?,
     val approveImageUrl: String?,
-    val registerAt: LocalDateTime,
 )

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineEntity.kt
@@ -18,6 +18,9 @@ class FineEntity(
     @JoinColumn(name = "attendance_id", nullable = false)
     var attendance: AttendanceEntity,
 
+    @Column(name = "amount", nullable = false)
+    val amount: Long,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "approve_status", nullable = false)
     val approveStatus: FineApproveStatus = FineApproveStatus.NEW,
@@ -33,7 +36,27 @@ class FineEntity(
 
     @Column(name = "moit_id", nullable = false)
     val moitId: Long,
-
     @Column(name = "study_id", nullable = false)
     val studyId: Long,
-) : BaseEntity()
+) : BaseEntity() {
+    fun toDomain(): Fine {
+        val isApproved = when (approveStatus) {
+            FineApproveStatus.APPROVED -> true
+            else -> false
+        }
+
+        return Fine(
+            id = id,
+            moitId = moitId,
+            studyId = attendance.studyId,
+            userId = userId,
+            attendanceStatus = attendance.status,
+            amount = amount,
+            isApproved = isApproved,
+            approveStatus = approveStatus,
+            approvedAt = approvedAt,
+            approveImageUrl = approveImageUrl,
+            registerAt = createdAt
+        )
+    }
+}

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineEntity.kt
@@ -55,8 +55,7 @@ class FineEntity(
             isApproved = isApproved,
             approveStatus = approveStatus,
             approvedAt = approvedAt,
-            approveImageUrl = approveImageUrl,
-            registerAt = createdAt
+            approveImageUrl = approveImageUrl
         )
     }
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineRepository.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineRepository.kt
@@ -1,0 +1,7 @@
+package com.mashup.moit.domain.fine
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FineRepository : JpaRepository<FineEntity, Long> {
+    fun findByMoitId(moitId: Long) : List<FineEntity>
+}

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineService.kt
@@ -1,0 +1,12 @@
+package com.mashup.moit.domain.fine
+
+import org.springframework.stereotype.Service
+
+@Service
+class FineService(
+    private val fineRepository: FineRepository
+) {
+    fun getFineListByMoitId(moitId: Long): List<Fine> {
+        return fineRepository.findByMoitId(moitId).map { it.toDomain() }
+    }
+}

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/fine/FineService.kt
@@ -7,6 +7,8 @@ class FineService(
     private val fineRepository: FineRepository
 ) {
     fun getFineListByMoitId(moitId: Long): List<Fine> {
-        return fineRepository.findByMoitId(moitId).map { it.toDomain() }
+        return fineRepository.findByMoitId(moitId)
+            .sortedByDescending { it.createdAt }
+            .map { it.toDomain() }
     }
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitService.kt
@@ -68,13 +68,7 @@ class MoitService(
             }
         }
     }
-
-    fun getMoitById(moitId: Long): Moit {
-        return moitRepository.findById(moitId)
-            .orElseThrow { MoitException.of(MoitExceptionType.NOT_EXIST) }
-            .toDomain()
-    }
-
+    
     fun getMoitByInvitationCode(invitationCode: String): Moit {
         return moitRepository.findByInvitationCode(invitationCode.uppercase(Locale.getDefault()))
             ?.also { it.validateDateForJoin() }?.toDomain()

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/moit/MoitService.kt
@@ -69,6 +69,12 @@ class MoitService(
         }
     }
 
+    fun getMoitById(moitId: Long): Moit {
+        return moitRepository.findById(moitId)
+            .orElseThrow { MoitException.of(MoitExceptionType.NOT_EXIST) }
+            .toDomain()
+    }
+
     fun getMoitByInvitationCode(invitationCode: String): Moit {
         return moitRepository.findByInvitationCode(invitationCode.uppercase(Locale.getDefault()))
             ?.also { it.validateDateForJoin() }?.toDomain()

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/Study.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/Study.kt
@@ -1,0 +1,7 @@
+package com.mashup.moit.domain.study
+
+data class Study(
+    val id: Long, 
+    val moitId: Long, 
+    val order: Int
+)

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyEntity.kt
@@ -35,4 +35,10 @@ class StudyEntity(
 
     @Column(name = "attendance_code")
     var attendanceCode: String? = null
+
+    fun toDomain() = Study(
+        id = id,
+        moitId = moitId,
+        order = order,
+    )
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyRepository.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyRepository.kt
@@ -2,6 +2,4 @@ package com.mashup.moit.domain.study
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface StudyRepository : JpaRepository<StudyEntity, Long> {
-    fun findByIdIn(ids: List<Long>): List<StudyEntity>
-}
+interface StudyRepository : JpaRepository<StudyEntity, Long>

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyRepository.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyRepository.kt
@@ -2,4 +2,6 @@ package com.mashup.moit.domain.study
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface StudyRepository : JpaRepository<StudyEntity, Long>
+interface StudyRepository : JpaRepository<StudyEntity, Long> {
+    fun findByIdIn(ids: List<Long>): List<StudyEntity>
+}

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyService.kt
@@ -14,6 +14,10 @@ class StudyService(
     private val studyRepository: StudyRepository,
     private val moitRepository: MoitRepository,
 ) {
+    fun findByStudyIds(ids: List<Long>): List<Study> {
+        return studyRepository.findByIdIn(ids).map { it.toDomain() }
+    }
+
     @Transactional
     fun createStudies(moitId: Long) {
         val moit = moitRepository.findById(moitId).orElseThrow { MoitException.of(MoitExceptionType.NOT_EXIST) }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyService.kt
@@ -15,7 +15,7 @@ class StudyService(
     private val moitRepository: MoitRepository,
 ) {
     fun findByStudyIds(ids: List<Long>): List<Study> {
-        return studyRepository.findByIdIn(ids).map { it.toDomain() }
+        return studyRepository.findAllById(ids).map { it.toDomain() }
     }
 
     @Transactional

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
@@ -8,6 +8,6 @@ data class User(
     val id: Long,
     val socialType: SocialType,
     // TODO UserEntity 에 먼저 추가 필요 (인증 작업 후 진행 필요)
-    val nickname: String = "default",
+    val nickname: String,
     val profileImage: Int = 1,
 )

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
@@ -19,21 +19,27 @@ class UserEntity(
 
     @Column(name = "kakao_id")
     val kakaoId: Long? = null,
+
+    @Column(name = "nickname")
+    val nickname: String,
 ) : BaseEntity() {
     fun toDomain() = User(
         id = id,
         socialType = socialType,
+        nickname = nickname
     )
 
     companion object {
-        fun createAppleUser(appleId: Long): UserEntity = UserEntity(
+        fun createAppleUser(appleId: Long, nickname: String): UserEntity = UserEntity(
             appleId = appleId,
-            socialType = SocialType.APPLE
+            socialType = SocialType.APPLE,
+            nickname = nickname
         )
 
-        fun createKakaoUser(kakaoId: Long): UserEntity = UserEntity(
+        fun createKakaoUser(kakaoId: Long, nickname: String): UserEntity = UserEntity(
             kakaoId = kakaoId,
-            socialType = SocialType.KAKAO
+            socialType = SocialType.KAKAO,
+            nickname = nickname
         )
     }
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserRepository.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserRepository.kt
@@ -2,4 +2,6 @@ package com.mashup.moit.domain.user
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface UserRepository : JpaRepository<UserEntity, Long>
+interface UserRepository : JpaRepository<UserEntity, Long> {
+    fun findByIdIn(ids: List<Long>): List<UserEntity>
+}


### PR DESCRIPTION
close : #58  / [notion link](https://www.notion.so/11-API-2315f3e1a7424196bdaa43b127579328) 

#59 내용과 겹치는 부분이 있어, 해당 pr 머지 후, 진행하도록 하겠습니다 

작업사항 
- moit 내 벌금 리스트 전체 조회 로직 구현
  - 기존 fine 내 벌금 금액에 대한 필드가 없어서 추가하였습니다 
    - fine 엔티티에서 moitId 로 moit에서 접근 후 정책 조회하는 방향으로 더 나은 방법이 있다면 말씀나누어봐요
  - [`@ManyToOne` 제거](https://github.com/mash-up-kr/MOIT-backend/pull/57)로 인해 유저이름? 닉네임 접근과 스터디 차수는 별도 접근하는 방식으로 변경 
 - study 와 user 엔티티의 순수 도메인 객체로 변경하는 부분은 이번엔 필요한 필드들만 추가하였으므로 추후에 부가적인 필드가 필요하다면, 추가하시면 될 듯 합니다  