### PR TITLE
feat: Security - 3. 로직 구체화

### DIFF
--- a/moit-api/src/main/kotlin/com/mashup/moit/common/MoitApiResponse.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/common/MoitApiResponse.kt
@@ -1,5 +1,7 @@
 package com.mashup.moit.common
 
+import com.mashup.moit.common.exception.MoitExceptionType
+
 data class MoitApiResponse<T>(
     val success: Boolean = true,
     val data: T? = null,
@@ -12,6 +14,18 @@ data class MoitApiResponse<T>(
                 data = data,
             )
         }
+
+        fun fail(moitExceptionType: MoitExceptionType, message: String?): MoitApiResponse<Unit> {
+            return MoitApiResponse(
+                success = true,
+                data = null,
+                error = MoitApiErrorResponse(
+                    code = moitExceptionType.errorCode,
+                    message = message ?: moitExceptionType.message,
+                )
+            )
+        }
+
     }
 }
 

--- a/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
@@ -4,10 +4,12 @@ import com.mashup.moit.security.JwtTokenFilter
 import com.mashup.moit.security.JwtTokenSupporter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.authentication.logout.LogoutHandler
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
@@ -27,7 +29,7 @@ class SecurityConfig(
             .oauth2Login { it.defaultSuccessUrl("/api/v1/auth/login/success") }
             .logout { it.logoutRequestMatcher(AntPathRequestMatcher("/logout")).addLogoutHandler(logoutHandler) }
             .authorizeHttpRequests {
-                it.anyRequest().authenticated()
+                it.anyRequest().authenticated() // TODO: 추후 인가 추가
             }
             .addFilterBefore(JwtTokenFilter(jwtTokenSupporter), UsernamePasswordAuthenticationFilter::class.java)
             .build()

--- a/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package com.mashup.moit.config
 
+import com.mashup.moit.controller.LoginController
 import com.mashup.moit.security.JwtTokenFilter
 import com.mashup.moit.security.JwtTokenSupporter
 import org.springframework.context.annotation.Bean
@@ -24,7 +25,7 @@ class SecurityConfig(
         return http
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
-            .oauth2Login { it.defaultSuccessUrl(LOGIN_ENDPOINT) }
+            .oauth2Login { it.defaultSuccessUrl(LoginController.LOGIN_SUCCESS_ENDPOINT) }
             .logout { it.logoutRequestMatcher(AntPathRequestMatcher("/logout")).addLogoutHandler(logoutHandler) }
             .authorizeHttpRequests {
                 it.anyRequest().authenticated()
@@ -37,14 +38,9 @@ class SecurityConfig(
     fun webSecurityCustomizer(): WebSecurityCustomizer {
         return WebSecurityCustomizer {
             it.ignoring().requestMatchers(
-                "/**", // TODO: update to authenticated() when complete security settings
                 "/am-i-alive/**",
             )
         }
-    }
-
-    companion object {
-        const val LOGIN_ENDPOINT = "/api/v1/sample/login"
     }
 
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
@@ -1,9 +1,11 @@
 package com.mashup.moit.config
 
-import com.mashup.moit.security.HttpStatusAccessDeniedHandler
-import com.mashup.moit.security.HttpStatusAuthenticationEntryPoint
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.mashup.moit.security.JwtTokenFilter
 import com.mashup.moit.security.JwtTokenSupporter
+import com.mashup.moit.security.handler.AuthFailureHandler
+import com.mashup.moit.security.handler.HttpStatusAccessDeniedHandler
+import com.mashup.moit.security.handler.HttpStatusAuthenticationEntryPoint
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -48,7 +50,10 @@ class SecurityConfig(
     fun webSecurityCustomizer(): WebSecurityCustomizer {
         return WebSecurityCustomizer {
             it.ignoring().requestMatchers(
+                "/**", // TODO: 개발 중이므로 다 제외
+                "/error/**",
                 "/am-i-alive/**",
+                "/api/v1/auth/register"
             )
         }
     }

--- a/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
@@ -18,7 +18,8 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 @EnableWebSecurity
 class SecurityConfig(
     private val logoutHandler: LogoutHandler,
-    private val jwtTokenSupporter: JwtTokenSupporter
+    private val jwtTokenSupporter: JwtTokenSupporter,
+    private val objectMapper: ObjectMapper
 ) {
 
     @Bean
@@ -31,7 +32,7 @@ class SecurityConfig(
             .authorizeHttpRequests {
                 it.anyRequest().authenticated() // TODO: 추후 인가 추가
             }
-            .addFilterBefore(JwtTokenFilter(jwtTokenSupporter), UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(JwtTokenFilter(jwtTokenSupporter, objectMapper), UsernamePasswordAuthenticationFilter::class.java)
             .exceptionHandling {
                 it.authenticationEntryPoint(HttpStatusAuthenticationEntryPoint())
                 it.accessDeniedHandler(HttpStatusAccessDeniedHandler())

--- a/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
@@ -27,7 +27,11 @@ class SecurityConfig(
         return http
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
-            .oauth2Login { it.defaultSuccessUrl("/api/v1/auth/login/success") }
+            .oauth2Login {
+                it.loginPage("/api/v1/auth/login")
+                    .defaultSuccessUrl("/api/v1/auth/login/success") // TODO: Use successHandler 
+                    .failureHandler(AuthFailureHandler())
+            }
             .logout { it.logoutRequestMatcher(AntPathRequestMatcher("/logout")).addLogoutHandler(logoutHandler) }
             .authorizeHttpRequests {
                 it.anyRequest().authenticated() // TODO: 추후 인가 추가

--- a/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
@@ -1,6 +1,5 @@
 package com.mashup.moit.config
 
-import com.mashup.moit.controller.AuthController
 import com.mashup.moit.security.JwtTokenFilter
 import com.mashup.moit.security.JwtTokenSupporter
 import org.springframework.context.annotation.Bean
@@ -25,7 +24,7 @@ class SecurityConfig(
         return http
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
-            .oauth2Login { it.defaultSuccessUrl(AuthController.SIGN_IN_SUCCESS_ENDPOINT) }
+            .oauth2Login { it.defaultSuccessUrl("/api/v1/auth/login/success") }
             .logout { it.logoutRequestMatcher(AntPathRequestMatcher("/logout")).addLogoutHandler(logoutHandler) }
             .authorizeHttpRequests {
                 it.anyRequest().authenticated()

--- a/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
@@ -1,6 +1,6 @@
 package com.mashup.moit.config
 
-import com.mashup.moit.controller.LoginController
+import com.mashup.moit.controller.AuthController
 import com.mashup.moit.security.JwtTokenFilter
 import com.mashup.moit.security.JwtTokenSupporter
 import org.springframework.context.annotation.Bean
@@ -25,7 +25,7 @@ class SecurityConfig(
         return http
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
-            .oauth2Login { it.defaultSuccessUrl(LoginController.LOGIN_SUCCESS_ENDPOINT) }
+            .oauth2Login { it.defaultSuccessUrl(AuthController.SIGN_IN_SUCCESS_ENDPOINT) }
             .logout { it.logoutRequestMatcher(AntPathRequestMatcher("/logout")).addLogoutHandler(logoutHandler) }
             .authorizeHttpRequests {
                 it.anyRequest().authenticated()

--- a/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/config/SecurityConfig.kt
@@ -1,15 +1,15 @@
 package com.mashup.moit.config
 
+import com.mashup.moit.security.HttpStatusAccessDeniedHandler
+import com.mashup.moit.security.HttpStatusAuthenticationEntryPoint
 import com.mashup.moit.security.JwtTokenFilter
 import com.mashup.moit.security.JwtTokenSupporter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.authentication.logout.LogoutHandler
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
@@ -32,6 +32,10 @@ class SecurityConfig(
                 it.anyRequest().authenticated() // TODO: 추후 인가 추가
             }
             .addFilterBefore(JwtTokenFilter(jwtTokenSupporter), UsernamePasswordAuthenticationFilter::class.java)
+            .exceptionHandling {
+                it.authenticationEntryPoint(HttpStatusAuthenticationEntryPoint())
+                it.accessDeniedHandler(HttpStatusAccessDeniedHandler())
+            }
             .build()
     }
 

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
@@ -24,7 +24,7 @@ class AuthController(
 ) {
 
     @Operation(summary = "로그인 시도", description = "로그인 시도 API - 웹 뷰로 지원 (Auth0 이용)")
-    @GetMapping("/login")
+    @GetMapping("/sign-in")
     fun signIn(): ResponseEntity<Unit> {
         val headers = HttpHeaders()
         headers.location = URI.create("/oauth2/authorization/auth0")
@@ -32,7 +32,7 @@ class AuthController(
     }
 
     @Operation(summary = "로그인 성공 (리다이렉트용)", description = "로그인 성공 API - 서버 단 Redirect 용")
-    @GetMapping("/login/success")
+    @GetMapping("/sign-in/success")
     fun signInSuccess(@AuthenticationPrincipal oidcUser: OidcUser): ResponseEntity<Any> {
         val user = userFacade.findByProviderUniqueKey(oidcUser)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(oidcUser.toBeforeSignUpInfo())
@@ -44,7 +44,7 @@ class AuthController(
     }
 
     @Operation(summary = "회원가입", description = "회원가입 API")
-    @PostMapping("/register")
+    @PostMapping("/sign-up")
     fun signUp(@RequestBody request: UserRegisterRequest): ResponseEntity<Any> {
         val jwtToken = userFacade.createUser(request).let { jwtTokenSupporter.createToken(UserInfo.from(it)) }
         return ResponseEntity.noContent()

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
@@ -4,8 +4,6 @@ import com.mashup.moit.facade.UserFacade
 import com.mashup.moit.security.JwtTokenSupporter
 import com.mashup.moit.security.OidcUser.toBeforeSignUpInfo
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -15,30 +13,28 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.web.bind.annotation.*
 import java.net.URI
 
-@Tag(name = "Sample", description = "Sample Login Api 입니다.")
+@Tag(name = "SignUp/SignIn API", description = "회원가입 및 로그인 Api 입니다.")
 @RequestMapping
 @RestController
-class LoginController(
+class AuthController(
     private val userFacade: UserFacade,
     private val jwtTokenSupporter: JwtTokenSupporter,
 ) {
 
-    @Operation(summary = "login API", description = "Login API")
-    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "OK")])
-    @GetMapping(LOGIN_ENDPOINT)
-    fun login(): ResponseEntity<Unit> {
+    @Operation(summary = "로그인 시도", description = "로그인 시도 API - 웹 뷰로 지원 (Auth0 이용)")
+    @GetMapping(SIGN_IN_ENDPOINT)
+    fun signIn(): ResponseEntity<Unit> {
         val headers = HttpHeaders()
         headers.location = URI.create("/oauth2/authorization/auth0")
         return ResponseEntity(headers, HttpStatus.MOVED_PERMANENTLY)
     }
 
-    @Operation(summary = "login success page", description = "Login Success API")
-    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "OK")])
-    @GetMapping(LOGIN_SUCCESS_ENDPOINT)
-    fun loginSuccess(@AuthenticationPrincipal oidcUser: OidcUser): ResponseEntity<Any> {
-        val user = userFacade.findByProviderUniqueKey(oidcUser) 
+    @Operation(summary = "로그인 성공 (리다이렉트용)", description = "로그인 성공 API - 서버 단 Redirect 용")
+    @GetMapping(SIGN_IN_SUCCESS_ENDPOINT)
+    fun signInSuccess(@AuthenticationPrincipal oidcUser: OidcUser): ResponseEntity<Any> {
+        val user = userFacade.findByProviderUniqueKey(oidcUser)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(oidcUser.toBeforeSignUpInfo())
-        
+
         val jwtToken = jwtTokenSupporter.createToken(oidcUser, user)
         return ResponseEntity.ok() // TODO: client와 야이기하고 no_content로 맞출지 이야기하보기
             .header(HttpHeaders.AUTHORIZATION, "${JwtTokenSupporter.BEARER_TOKEN_PREFIX} $jwtToken")
@@ -46,8 +42,9 @@ class LoginController(
     }
 
     companion object {
-        const val LOGIN_ENDPOINT = "/api/v1/login"
-        const val LOGIN_SUCCESS_ENDPOINT = "/api/v1/login/success"
+        const val SIGN_IN_ENDPOINT = "/api/v1/auth/login"
+        const val SIGN_IN_SUCCESS_ENDPOINT = "/api/v1/auth/login/success"
+        const val SIGN_UP_SUCCESS_ENDPOINT = "/api/v1/auth/register"
     }
 
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
@@ -3,8 +3,8 @@ package com.mashup.moit.controller
 import com.mashup.moit.controller.dto.UserRegisterRequest
 import com.mashup.moit.facade.UserFacade
 import com.mashup.moit.security.JwtTokenSupporter
-import com.mashup.moit.security.OidcUser.toBeforeSignUpInfo
 import com.mashup.moit.security.UserInfo
+import com.mashup.moit.security.toBeforeSignUpInfo
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpHeaders

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
@@ -1,8 +1,10 @@
 package com.mashup.moit.controller
 
+import com.mashup.moit.controller.dto.UserRegisterRequest
 import com.mashup.moit.facade.UserFacade
 import com.mashup.moit.security.JwtTokenSupporter
 import com.mashup.moit.security.OidcUser.toBeforeSignUpInfo
+import com.mashup.moit.security.UserInfo
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpHeaders
@@ -14,7 +16,7 @@ import org.springframework.web.bind.annotation.*
 import java.net.URI
 
 @Tag(name = "SignUp/SignIn API", description = "회원가입 및 로그인 Api 입니다.")
-@RequestMapping
+@RequestMapping("/api/v1/auth")
 @RestController
 class AuthController(
     private val userFacade: UserFacade,
@@ -22,7 +24,7 @@ class AuthController(
 ) {
 
     @Operation(summary = "로그인 시도", description = "로그인 시도 API - 웹 뷰로 지원 (Auth0 이용)")
-    @GetMapping(SIGN_IN_ENDPOINT)
+    @GetMapping("/login")
     fun signIn(): ResponseEntity<Unit> {
         val headers = HttpHeaders()
         headers.location = URI.create("/oauth2/authorization/auth0")
@@ -30,21 +32,24 @@ class AuthController(
     }
 
     @Operation(summary = "로그인 성공 (리다이렉트용)", description = "로그인 성공 API - 서버 단 Redirect 용")
-    @GetMapping(SIGN_IN_SUCCESS_ENDPOINT)
+    @GetMapping("/login/success")
     fun signInSuccess(@AuthenticationPrincipal oidcUser: OidcUser): ResponseEntity<Any> {
         val user = userFacade.findByProviderUniqueKey(oidcUser)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(oidcUser.toBeforeSignUpInfo())
 
-        val jwtToken = jwtTokenSupporter.createToken(oidcUser, user)
-        return ResponseEntity.ok() // TODO: client와 야이기하고 no_content로 맞출지 이야기하보기
+        val jwtToken = jwtTokenSupporter.createToken(UserInfo.from(user))
+        return ResponseEntity.noContent()
             .header(HttpHeaders.AUTHORIZATION, "${JwtTokenSupporter.BEARER_TOKEN_PREFIX} $jwtToken")
             .build()
     }
 
-    companion object {
-        const val SIGN_IN_ENDPOINT = "/api/v1/auth/login"
-        const val SIGN_IN_SUCCESS_ENDPOINT = "/api/v1/auth/login/success"
-        const val SIGN_UP_SUCCESS_ENDPOINT = "/api/v1/auth/register"
+    @Operation(summary = "회원가입", description = "회원가입 API")
+    @PostMapping("/register")
+    fun signUp(@RequestBody request: UserRegisterRequest): ResponseEntity<Any> {
+        val jwtToken = userFacade.createUser(request).let { jwtTokenSupporter.createToken(UserInfo.from(it)) }
+        return ResponseEntity.noContent()
+            .header(HttpHeaders.AUTHORIZATION, "${JwtTokenSupporter.BEARER_TOKEN_PREFIX} $jwtToken")
+            .build()
     }
 
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/LoginController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/LoginController.kt
@@ -1,4 +1,4 @@
-package com.mashup.moit.sample.controller.sample
+package com.mashup.moit.controller
 
 import com.mashup.moit.security.JwtTokenSupporter
 import io.swagger.v3.oas.annotations.Operation
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*
 import java.net.URI
 
 @Tag(name = "Sample", description = "Sample Login Api 입니다.")
-@RequestMapping("/api/v1/sample/login")
+@RequestMapping
 @RestController
 class LoginController(
     private val jwtTokenSupporter: JwtTokenSupporter
@@ -22,17 +22,27 @@ class LoginController(
 
     @Operation(summary = "login API", description = "Login API")
     @ApiResponses(value = [ApiResponse(responseCode = "200", description = "OK")])
-    @GetMapping
-    fun login(@AuthenticationPrincipal user: OidcUser?): ResponseEntity<Unit> {
-        if (user != null) {
-            val jwtToken = jwtTokenSupporter.createToken(user)
-            return ResponseEntity.noContent()
-                .header(HttpHeaders.AUTHORIZATION, "${JwtTokenSupporter.BEARER_TOKEN_PREFIX} $jwtToken")
-                .build()
-        }
+    @GetMapping(LOGIN_ENDPOINT)
+    fun login(): ResponseEntity<Unit> {
         val headers = HttpHeaders()
         headers.location = URI.create("/oauth2/authorization/auth0")
         return ResponseEntity(headers, HttpStatus.MOVED_PERMANENTLY)
+    }
+
+    @Operation(summary = "login success page", description = "Login Success API")
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "OK")])
+    @GetMapping(LOGIN_SUCCESS_ENDPOINT)
+    fun loginSuccess(@AuthenticationPrincipal user: OidcUser): ResponseEntity<Unit> {
+        val jwtToken = jwtTokenSupporter.createToken(user)
+        // TODO: client와 야이기하고 no_content로 맞출지 이야기하보기
+        return ResponseEntity.ok()
+            .header(HttpHeaders.AUTHORIZATION, "${JwtTokenSupporter.BEARER_TOKEN_PREFIX} $jwtToken")
+            .build()
+    }
+
+    companion object {
+        const val LOGIN_ENDPOINT = "/api/v1/login"
+        const val LOGIN_SUCCESS_ENDPOINT = "/api/v1/login/success"
     }
 
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/dto/UserBeforeSignUpInfoResponse.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/dto/UserBeforeSignUpInfoResponse.kt
@@ -1,7 +1,7 @@
 package com.mashup.moit.controller.dto
 
-class UserBeforeSignUpInfoResponse(
+data class UserBeforeSignUpInfoResponse(
     val providerUniqueKey: String,
     val nickname: String,
-    val eamil: String
+    val email: String
 )

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/dto/UserBeforeSignUpInfoResponse.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/dto/UserBeforeSignUpInfoResponse.kt
@@ -1,0 +1,7 @@
+package com.mashup.moit.controller.dto
+
+class UserBeforeSignUpInfoResponse(
+    val providerUniqueKey: String,
+    val nickname: String,
+    val eamil: String
+)

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/dto/UserRegisterRequest.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/dto/UserRegisterRequest.kt
@@ -1,0 +1,8 @@
+package com.mashup.moit.controller.dto
+
+data class UserRegisterRequest(
+    val providerUniqueKey: String,
+    val nickname: String,
+    val email: String,
+    val profileImage: Int
+)

--- a/moit-api/src/main/kotlin/com/mashup/moit/facade/UserFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/facade/UserFacade.kt
@@ -1,5 +1,6 @@
 package com.mashup.moit.facade
 
+import com.mashup.moit.controller.dto.UserRegisterRequest
 import com.mashup.moit.domain.user.User
 import com.mashup.moit.domain.user.UserService
 import com.mashup.moit.security.OidcUser.getProviderUniqueKey
@@ -13,6 +14,15 @@ class UserFacade(
 
     fun findByProviderUniqueKey(oidcUser: OidcUser): User? {
         return userService.findByProviderUniqueKey(oidcUser.getProviderUniqueKey())
+    }
+
+    fun createUser(userRegisterRequest: UserRegisterRequest): User {
+        return userService.createUser(
+            userRegisterRequest.providerUniqueKey,
+            userRegisterRequest.nickname,
+            userRegisterRequest.profileImage,
+            userRegisterRequest.email
+        )
     }
 
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/facade/UserFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/facade/UserFacade.kt
@@ -3,7 +3,7 @@ package com.mashup.moit.facade
 import com.mashup.moit.controller.dto.UserRegisterRequest
 import com.mashup.moit.domain.user.User
 import com.mashup.moit.domain.user.UserService
-import com.mashup.moit.security.OidcUser.getProviderUniqueKey
+import com.mashup.moit.security.getProviderUniqueKey
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.stereotype.Component
 

--- a/moit-api/src/main/kotlin/com/mashup/moit/facade/UserFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/facade/UserFacade.kt
@@ -1,0 +1,18 @@
+package com.mashup.moit.facade
+
+import com.mashup.moit.domain.user.User
+import com.mashup.moit.domain.user.UserService
+import com.mashup.moit.security.OidcUser.getProviderUniqueKey
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.stereotype.Component
+
+@Component
+class UserFacade(
+    private val userService: UserService
+) {
+
+    fun findByProviderUniqueKey(oidcUser: OidcUser): User? {
+        return userService.findByProviderUniqueKey(oidcUser.getProviderUniqueKey())
+    }
+
+}

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/JwtTokenFilter.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/JwtTokenFilter.kt
@@ -2,7 +2,6 @@ package com.mashup.moit.security
 
 import com.mashup.moit.common.exception.MoitException
 import com.mashup.moit.common.exception.MoitExceptionType
-import com.mashup.moit.controller.AuthController
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -49,7 +48,16 @@ class JwtTokenFilter(
 
     companion object {
         private const val AUTH_PROVIDER_SPLIT_DELIMITER: String = " "
-        private val NOT_CHECK_ENDPOINTS = listOf(AuthController.SIGN_IN_ENDPOINT, AuthController.SIGN_IN_SUCCESS_ENDPOINT)
+        private val NOT_CHECK_ENDPOINTS = listOf(
+            // Common
+            "/favicon.ico",
+            "/error",
+            // Swagger
+            "/api-docs", "/swagger-ui", "/swagger-resources", "/v3/api-docs",
+            // SignIn/SignUp Endpoints
+            "/api/v1/auth",
+            "/oauth2",
+        )
     }
 
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/JwtTokenFilter.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/JwtTokenFilter.kt
@@ -1,6 +1,7 @@
 package com.mashup.moit.security
 
-import com.mashup.moit.common.exception.MoitException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mashup.moit.common.MoitApiResponse
 import com.mashup.moit.common.exception.MoitExceptionType
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
@@ -8,43 +9,53 @@ import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.core.AuthenticationException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 
 class JwtTokenFilter(
-    private val jwtTokenSupporter: JwtTokenSupporter
+    private val jwtTokenSupporter: JwtTokenSupporter,
+    private val objectMapper: ObjectMapper
 ) : OncePerRequestFilter() {
 
     private val log: Logger = LoggerFactory.getLogger(JwtTokenFilter::class.java)
 
     override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
-        if (!isNotCheckEndpoint(request)) {
-            extractToken(request)?.run {
-                val user = jwtTokenSupporter.extractUserFromToken(this)
-                SecurityContextHolder.getContext().authentication = JwtAuthentication(user)
+        log.info("JWT Token Filter")
+        try {
+            setAuthenticationFromToken(request)
+            filterChain.doFilter(request, response)
+        } catch (authException: AuthenticationException) {
+            SecurityContextHolder.clearContext()
+            response.run {
+                val failResponse = MoitApiResponse.fail(MoitExceptionType.AUTH_ERROR, authException.message)
+                status = HttpStatus.UNAUTHORIZED.value()
+                writer.write(objectMapper.writeValueAsString(failResponse))
             }
         }
-        filterChain.doFilter(request, response)
     }
 
-    /**
-     * 요청으로부터 Token 추출
-     * - Authorization Header value 로 부터 BEARER 이후 값 추출
-     *
-     * @return JWT token String
-     */
-    private fun extractToken(request: HttpServletRequest): String? {
-        val authorization = request.getAuthorization()
-        log.debug("Parsing token in header: $authorization - Request path: ${request.requestURI}")
-        return authorization.split(AUTH_PROVIDER_SPLIT_DELIMITER)
-            .takeIf { it[0] == JwtTokenSupporter.BEARER_TOKEN_PREFIX }
-            ?.get(1)
+    private fun setAuthenticationFromToken(request: HttpServletRequest) {
+        if (!isNotCheckEndpoint(request)) {
+            val authorization = request.getAuthorization()
+            log.debug("Parsing token in header: $authorization - Request path: ${request.requestURI}")
+            getToken(authorization)?.run {
+                val user = jwtTokenSupporter.extractUserFromToken(this)
+                SecurityContextHolder.getContext().authentication = JwtAuthentication(user)
+            } ?: throw BadCredentialsException(MoitExceptionType.INVALID_USER_AUTH_TOKEN.message)
+        }
     }
 
     private fun isNotCheckEndpoint(request: HttpServletRequest) = NOT_CHECK_ENDPOINTS.stream().anyMatch { request.requestURI.startsWith(it) }
 
     private fun HttpServletRequest.getAuthorization() =
-        this.getHeader(HttpHeaders.AUTHORIZATION) ?: throw MoitException.of(MoitExceptionType.INVALID_USER_AUTH_TOKEN)
+        this.getHeader(HttpHeaders.AUTHORIZATION) ?: throw BadCredentialsException(MoitExceptionType.EMPTY_AUTHORIZATION_HEADER.message)
+
+    private fun getToken(authorization: String) = authorization.split(AUTH_PROVIDER_SPLIT_DELIMITER)
+        .takeIf { it[0] == JwtTokenSupporter.BEARER_TOKEN_PREFIX }
+        ?.get(1)
 
     companion object {
         private const val AUTH_PROVIDER_SPLIT_DELIMITER: String = " "
@@ -57,6 +68,7 @@ class JwtTokenFilter(
             // SignIn/SignUp Endpoints
             "/api/v1/auth",
             "/oauth2",
+            "/login/oauth2",
         )
     }
 

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/JwtTokenFilter.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/JwtTokenFilter.kt
@@ -2,7 +2,7 @@ package com.mashup.moit.security
 
 import com.mashup.moit.common.exception.MoitException
 import com.mashup.moit.common.exception.MoitExceptionType
-import com.mashup.moit.controller.LoginController
+import com.mashup.moit.controller.AuthController
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -49,7 +49,7 @@ class JwtTokenFilter(
 
     companion object {
         private const val AUTH_PROVIDER_SPLIT_DELIMITER: String = " "
-        private val NOT_CHECK_ENDPOINTS = listOf(LoginController.LOGIN_ENDPOINT, LoginController.LOGIN_SUCCESS_ENDPOINT)
+        private val NOT_CHECK_ENDPOINTS = listOf(AuthController.SIGN_IN_ENDPOINT, AuthController.SIGN_IN_SUCCESS_ENDPOINT)
     }
 
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/JwtTokenSupporter.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/JwtTokenSupporter.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.mashup.moit.common.exception.MoitException
 import com.mashup.moit.common.exception.MoitExceptionType
 import com.mashup.moit.domain.sample.SampleUser
+import com.mashup.moit.domain.user.User
 import io.jsonwebtoken.JwtParser
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
@@ -31,14 +32,14 @@ class JwtTokenSupporter(
     /**
      * Moit JWT Token 생성
      *
-     * @param user 로그인 유저
+     * @param oidcUser 로그인 유저
      * @return JWT Token
      */
-    fun createToken(user: OidcUser): String {
+    fun createToken(oidcUser: OidcUser, moitUser: User): String {
         val issuerDateTime = LocalDateTime.now(ASIA_SEOUL_ZONE)
         val expiredDateTime = issuerDateTime.plusDays(DAY_30)
-        val subject = user.getAttribute<String>(CLAIM_SUB_KEY)
-        val audience = user.getAttribute<List<String>>(CLAIM_AUD_KEY)?.get(0)
+        val subject = oidcUser.getAttribute<String>(CLAIM_SUB_KEY)
+        val audience = oidcUser.getAttribute<List<String>>(CLAIM_AUD_KEY)?.get(0)
         return Jwts.builder()
             .setHeaderParam("typ", "JWT")
             .setSubject(subject)
@@ -46,7 +47,7 @@ class JwtTokenSupporter(
             .setIssuer("https://github.com/mash-up-kr/MOIT-backend")
             .setIssuedAt(issuerDateTime.convertToDate())
             .setExpiration(expiredDateTime.convertToDate())
-            .claim(CLAIM_INFO_KEY, convertToUser(user))
+            .claim(CLAIM_INFO_KEY, moitUser)
             .signWith(secretKey)
             .compact()
     }
@@ -64,39 +65,6 @@ class JwtTokenSupporter(
     }
 
     /**
-     * Auth0 로그인 유저를 Moit 유저 클래스로 변환
-     * TODO: SampleUser -> Entity Data User 전환 필요
-     *
-     * @param user Auth0 User
-     * @return MoitUser
-     */
-    private fun convertToUser(user: OidcUser): SampleUser {
-        return user.userInfo!!.let {
-            val email = it.getClaimAsString("email")
-            val authProvider = getAuthProvider(it.getClaimAsString(CLAIM_SUB_KEY))
-            val providerUniqueKey = "$authProvider$PROVIDER_SPLIT_DELIMITER$email"
-            SampleUser(
-                providerUniqueKey = providerUniqueKey,
-                email = email,
-                profileImage = it.getClaimAsString("picture"),
-                nickname = it.getClaimAsString("nickname")
-            )
-        }
-    }
-
-    /**
-     * Auth0 Claim 정보로부터 OAuth Provider 추출
-     *
-     * @param jwtClaim Auth0 JWT Claim
-     * @return OAuth provider
-     */
-    private fun getAuthProvider(jwtClaim: String): String {
-        val lastIndex = jwtClaim.lastIndexOf(PROVIDER_SPLIT_DELIMITER)
-        return jwtClaim.takeIf { lastIndex > 0 }?.substring(0, lastIndex)
-            ?: throw MoitException.of(MoitExceptionType.INVALID_AUTH_PROVIDER)
-    }
-
-    /**
      * jjwt 지원을 위해 LocalDateTime to Date 변환하는 확장함수
      *
      * @return date
@@ -105,11 +73,10 @@ class JwtTokenSupporter(
 
     companion object {
         const val BEARER_TOKEN_PREFIX = "BEARER"
-        private const val PROVIDER_SPLIT_DELIMITER = "|"
+        const val CLAIM_INFO_KEY = "info"
+        const val CLAIM_AUD_KEY = "aud"
+        const val CLAIM_SUB_KEY = "sub"
         private const val DAY_30 = 30L
-        private const val CLAIM_INFO_KEY = "info"
-        private const val CLAIM_AUD_KEY = "aud"
-        private const val CLAIM_SUB_KEY = "sub"
         private val ASIA_SEOUL_ZONE = ZoneId.of("Asia/Seoul")
         private val ASIA_SEOUL_OFFSET = ZoneOffset.of("+09:00")
     }

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/OidcUser.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/OidcUser.kt
@@ -5,30 +5,29 @@ import com.mashup.moit.common.exception.MoitExceptionType
 import com.mashup.moit.controller.dto.UserBeforeSignUpInfoResponse
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 
-object OidcUser {
+private const val PROVIDER_SPLIT_DELIMITER = "|"
+private const val CLAIM_SUB_KEY = "sub"
+private const val CLAIM_EMAIL_KEY = "email"
+private const val CLAIM_NICKNAME_KEY = "nickname"
 
-    fun OidcUser.getAuthProvider(): String {
-        val jwtClaim = this.getClaimAsString(CLAIM_SUB_KEY)
-        val lastIndex = jwtClaim.lastIndexOf(PROVIDER_SPLIT_DELIMITER)
-        return jwtClaim.takeIf { lastIndex > 0 }?.substring(0, lastIndex)
-            ?: throw MoitException.of(MoitExceptionType.INVALID_AUTH_PROVIDER)
-    }
 
-    fun OidcUser.getProviderUniqueKey(): String {
-        val email = this.getClaimAsString(CLAIM_EMAIL_KEY)
-        val authProvider = this.getAuthProvider()
-        return "$authProvider${PROVIDER_SPLIT_DELIMITER}$email"
-    }
-
-    fun OidcUser.toBeforeSignUpInfo(): UserBeforeSignUpInfoResponse {
-        val email = this.getClaimAsString(CLAIM_EMAIL_KEY)
-        val nickname = this.getClaimAsString(CLAIM_NICKNAME_KEY)
-        val authProviderUniqueKey = this.getProviderUniqueKey()
-        return UserBeforeSignUpInfoResponse(authProviderUniqueKey, nickname, email)
-    }
-
-    private const val PROVIDER_SPLIT_DELIMITER = "|"
-    private const val CLAIM_SUB_KEY = "sub"
-    private const val CLAIM_EMAIL_KEY = "email"
-    private const val CLAIM_NICKNAME_KEY = "nickname"
+fun OidcUser.getAuthProvider(): String {
+    val jwtClaim = this.getClaimAsString(CLAIM_SUB_KEY)
+    val lastIndex = jwtClaim.lastIndexOf(PROVIDER_SPLIT_DELIMITER)
+    return jwtClaim.takeIf { lastIndex > 0 }?.substring(0, lastIndex)
+        ?: throw MoitException.of(MoitExceptionType.INVALID_AUTH_PROVIDER)
 }
+
+fun OidcUser.getProviderUniqueKey(): String {
+    val email = this.getClaimAsString(CLAIM_EMAIL_KEY)
+    val authProvider = this.getAuthProvider()
+    return "$authProvider${PROVIDER_SPLIT_DELIMITER}$email"
+}
+
+fun OidcUser.toBeforeSignUpInfo(): UserBeforeSignUpInfoResponse {
+    val email = this.getClaimAsString(CLAIM_EMAIL_KEY)
+    val nickname = this.getClaimAsString(CLAIM_NICKNAME_KEY)
+    val authProviderUniqueKey = this.getProviderUniqueKey()
+    return UserBeforeSignUpInfoResponse(authProviderUniqueKey, nickname, email)
+}
+

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/OidcUser.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/OidcUser.kt
@@ -1,0 +1,34 @@
+package com.mashup.moit.security
+
+import com.mashup.moit.common.exception.MoitException
+import com.mashup.moit.common.exception.MoitExceptionType
+import com.mashup.moit.controller.dto.UserBeforeSignUpInfoResponse
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+
+object OidcUser {
+
+    fun OidcUser.getAuthProvider(): String {
+        val jwtClaim = this.getClaimAsString(CLAIM_SUB_KEY)
+        val lastIndex = jwtClaim.lastIndexOf(PROVIDER_SPLIT_DELIMITER)
+        return jwtClaim.takeIf { lastIndex > 0 }?.substring(0, lastIndex)
+            ?: throw MoitException.of(MoitExceptionType.INVALID_AUTH_PROVIDER)
+    }
+
+    fun OidcUser.getProviderUniqueKey(): String {
+        val email = this.getClaimAsString(CLAIM_EMAIL_KEY)
+        val authProvider = this.getAuthProvider()
+        return "$authProvider${PROVIDER_SPLIT_DELIMITER}$email"
+    }
+
+    fun OidcUser.toBeforeSignUpInfo(): UserBeforeSignUpInfoResponse {
+        val email = this.getClaimAsString(CLAIM_EMAIL_KEY)
+        val nickname = this.getClaimAsString(CLAIM_NICKNAME_KEY)
+        val authProviderUniqueKey = this.getProviderUniqueKey()
+        return UserBeforeSignUpInfoResponse(authProviderUniqueKey, nickname, email)
+    }
+
+    private const val PROVIDER_SPLIT_DELIMITER = "|"
+    private const val CLAIM_SUB_KEY = "sub"
+    private const val CLAIM_EMAIL_KEY = "email"
+    private const val CLAIM_NICKNAME_KEY = "nickname"
+}

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/UserInfo.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/UserInfo.kt
@@ -1,0 +1,23 @@
+package com.mashup.moit.security
+
+import com.mashup.moit.domain.user.User
+
+data class UserInfo(
+    val id: Long,
+    val providerUniqueKey: String,
+    val nickname: String,
+    val profileImage: Int,
+    val email: String,
+) {
+    companion object {
+        fun from(user: User): UserInfo {
+            return UserInfo(
+                user.id,
+                user.providerUniqueKey,
+                user.nickname,
+                user.profileImage,
+                user.email
+            )
+        }
+    }
+}

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/handler/AuthFailureHandler.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/handler/AuthFailureHandler.kt
@@ -1,0 +1,24 @@
+package com.mashup.moit.security.handler
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
+
+
+class AuthFailureHandler : AuthenticationFailureHandler {
+    private val log: Logger = LoggerFactory.getLogger(AuthFailureHandler::class.java)
+
+    override fun onAuthenticationFailure(
+        httpServletRequest: HttpServletRequest,
+        httpServletResponse: HttpServletResponse,
+        authenticationException: AuthenticationException
+    ) {
+        log.debug("Fail Authentication: ${authenticationException.message}")
+        httpServletResponse.status = HttpStatus.UNAUTHORIZED.value()
+    }
+}
+

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/handler/HttpStatusAccessDeniedHandler.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/handler/HttpStatusAccessDeniedHandler.kt
@@ -1,0 +1,22 @@
+package com.mashup.moit.security.handler
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+
+class HttpStatusAccessDeniedHandler : AccessDeniedHandler {
+    private val log: Logger = LoggerFactory.getLogger(HttpStatusAccessDeniedHandler::class.java)
+
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+        log.debug("Access Denied: ${accessDeniedException.message}")
+        response.status = HttpStatus.FORBIDDEN.value()
+    }
+}

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/handler/HttpStatusAuthenticationEntryPoint.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/handler/HttpStatusAuthenticationEntryPoint.kt
@@ -1,0 +1,23 @@
+package com.mashup.moit.security.handler
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+
+
+class HttpStatusAuthenticationEntryPoint() : AuthenticationEntryPoint {
+    private val log: Logger = LoggerFactory.getLogger(HttpStatusAuthenticationEntryPoint::class.java)
+
+    override fun commence(
+        request: HttpServletRequest, response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        log.debug("Not Authenticated: ${authException.message}")
+        response.status = HttpStatus.UNAUTHORIZED.value()
+    }
+}
+

--- a/moit-api/src/test/kotlin/com/mashup/moit/security/JwtTokenFilterTest.kt
+++ b/moit-api/src/test/kotlin/com/mashup/moit/security/JwtTokenFilterTest.kt
@@ -1,6 +1,6 @@
 package com.mashup.moit.security
 
-import com.mashup.moit.config.SecurityConfig
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.mashup.moit.domain.sample.SampleUser
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -20,10 +20,11 @@ class JwtTokenFilterTest : DescribeSpec() {
 
     private val jwtTokenFilter: JwtTokenFilter
     private val jwtTokenSupporter = mockk<JwtTokenSupporter>()
+    private val objectMapper = mockk<ObjectMapper>()
     private val filterChain = mockk<FilterChain>()
 
     init {
-        this.jwtTokenFilter = JwtTokenFilter(jwtTokenSupporter)
+        this.jwtTokenFilter = JwtTokenFilter(jwtTokenSupporter, objectMapper)
 
         beforeContainer {
             every { filterChain.doFilter(any(), any()) } just Runs
@@ -35,7 +36,7 @@ class JwtTokenFilterTest : DescribeSpec() {
 
         describe("JwtTokenFilter로") {
             context("token 검사가 필요없는 엔드포인트에서 요청이 온 경우") {
-                val request = MockHttpServletRequest("GET", SecurityConfig.LOGIN_ENDPOINT)
+                val request = MockHttpServletRequest("GET", "/error")
                 val response = MockHttpServletResponse()
                 jwtTokenFilter.doFilter(request, response, filterChain)
 

--- a/moit-common/src/main/kotlin/com/mashup/moit/common/exception/MoitExceptionType.kt
+++ b/moit-common/src/main/kotlin/com/mashup/moit/common/exception/MoitExceptionType.kt
@@ -7,8 +7,9 @@ enum class MoitExceptionType(
 ) {
     // USER
     AUTH_ERROR("유저 프로세스에서 오류가 발생했습니다.", "U000_AUTH_ERROR", 500),
-    INVALID_USER_AUTH_TOKEN("Invalid JWT Token", "U001_INVALID_TOKEN", 400),
-    INVALID_AUTH_PROVIDER("Invalid provider by auth0. Check social section of auth0", "U002_INVALID_AUTH_PROVIDER", 500),
+    EMPTY_AUTHORIZATION_HEADER("Not Exist Authorization Header", "U001_EMPTY_AUTHORIZATION_HEADER", 400),
+    INVALID_USER_AUTH_TOKEN("Invalid JWT Token", "U002_INVALID_TOKEN", 400),
+    INVALID_AUTH_PROVIDER("Invalid provider by auth0. Check social section of auth0", "U003_INVALID_AUTH_PROVIDER", 500),
     
     // COMMON
     NOT_EXIST("존재하지 않습니다.", "C001_NOT_EXIST", 404),

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
@@ -10,6 +10,8 @@ class User(
     private var updatedAt: LocalDateTime,
     private val isDeleted: Boolean,
     private val providerUniqueKey: String,
+    private val nickname: String,
+    private val profileImage: Int,
     private val attendances: List<AttendanceEntity>,
     val userMoits: List<UserMoitEntity>
 )

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
@@ -1,5 +1,15 @@
 package com.mashup.moit.domain.user
 
-enum class SocialType {
-    KAKAO, APPLE;
-}
+import com.mashup.moit.domain.attendance.AttendanceEntity
+import com.mashup.moit.domain.usermoit.UserMoitEntity
+import java.time.LocalDateTime
+
+class User(
+    private val id: Long,
+    private var createdAt: LocalDateTime,
+    private var updatedAt: LocalDateTime,
+    private val isDeleted: Boolean,
+    private val providerUniqueKey: String,
+    private val attendances: List<AttendanceEntity>,
+    val userMoits: List<UserMoitEntity>
+)

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
@@ -12,6 +12,7 @@ class User(
     private val providerUniqueKey: String,
     private val nickname: String,
     private val profileImage: Int,
-    private val attendances: List<AttendanceEntity>,
-    val userMoits: List<UserMoitEntity>
+    private val email: String,
+    private val attendances: List<AttendanceEntity>? = null,
+    val userMoits: List<UserMoitEntity>? = null
 )

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/User.kt
@@ -5,14 +5,14 @@ import com.mashup.moit.domain.usermoit.UserMoitEntity
 import java.time.LocalDateTime
 
 class User(
-    private val id: Long,
-    private var createdAt: LocalDateTime,
-    private var updatedAt: LocalDateTime,
-    private val isDeleted: Boolean,
-    private val providerUniqueKey: String,
-    private val nickname: String,
-    private val profileImage: Int,
-    private val email: String,
-    private val attendances: List<AttendanceEntity>? = null,
+    val id: Long,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val isDeleted: Boolean,
+    val providerUniqueKey: String,
+    val nickname: String,
+    val profileImage: Int,
+    val email: String,
+    val attendances: List<AttendanceEntity>? = null,
     val userMoits: List<UserMoitEntity>? = null
 )

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
@@ -13,6 +13,12 @@ import jakarta.persistence.Table
 class UserEntity(
     @Column(name = "provider_unique_key")
     val providerUniqueKey: String,
+
+    @Column(name = "nickname")
+    val nickname: String,
+
+    @Column(name = "profile_image")
+    val profileImage: Int,
 ) : BaseEntity() {
     @OneToMany(mappedBy = "user")
     val attendances: List<AttendanceEntity> = emptyList()
@@ -27,9 +33,11 @@ class UserEntity(
             updatedAt = updatedAt,
             isDeleted = isDeleted,
             providerUniqueKey = providerUniqueKey,
+            nickname = nickname,
+            profileImage = profileImage,
             attendances = attendances,
             userMoits = userMoits
         )
     }
-    
+
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
@@ -5,23 +5,14 @@ import com.mashup.moit.domain.common.BaseEntity
 import com.mashup.moit.domain.usermoit.UserMoitEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 
 @Table(name = "users")
 @Entity
 class UserEntity(
-    @Enumerated(EnumType.STRING)
-    @Column(name = "social_type", nullable = false)
-    val socialType: SocialType,
-
-    @Column(name = "apple_id")
-    val appleId: Long? = null,
-
-    @Column(name = "kakao_id")
-    val kakaoId: Long? = null,
+    @Column(name = "provider_unique_key")
+    val providerUniqueKey: String,
 ) : BaseEntity() {
     @OneToMany(mappedBy = "user")
     val attendances: List<AttendanceEntity> = emptyList()
@@ -29,15 +20,16 @@ class UserEntity(
     @OneToMany(mappedBy = "user")
     val userMoits: List<UserMoitEntity> = emptyList()
 
-    companion object {
-        fun createAppleUser(appleId: Long): UserEntity = UserEntity(
-            appleId = appleId,
-            socialType = SocialType.APPLE
-        )
-
-        fun createKakaoUser(kakaoId: Long): UserEntity = UserEntity(
-            kakaoId = kakaoId,
-            socialType = SocialType.KAKAO
+    fun toDomain(): User {
+        return User(
+            id = id,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            isDeleted = isDeleted,
+            providerUniqueKey = providerUniqueKey,
+            attendances = attendances,
+            userMoits = userMoits
         )
     }
+    
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
@@ -19,6 +19,9 @@ class UserEntity(
 
     @Column(name = "profile_image")
     val profileImage: Int,
+    
+    @Column(name = "email")
+    val email: String
 ) : BaseEntity() {
     @OneToMany(mappedBy = "user")
     val attendances: List<AttendanceEntity> = emptyList()
@@ -35,6 +38,7 @@ class UserEntity(
             providerUniqueKey = providerUniqueKey,
             nickname = nickname,
             profileImage = profileImage,
+            email = email,
             attendances = attendances,
             userMoits = userMoits
         )

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserEntity.kt
@@ -1,26 +1,23 @@
 package com.mashup.moit.domain.user
 
-import com.mashup.moit.domain.attendance.AttendanceEntity
 import com.mashup.moit.domain.common.BaseEntity
-import com.mashup.moit.domain.usermoit.UserMoitEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 
 @Table(name = "users")
 @Entity
 class UserEntity(
-    @Column(name = "provider_unique_key")
+    @Column(name = "provider_unique_key", nullable = false)
     val providerUniqueKey: String,
 
-    @Column(name = "nickname")
+    @Column(name = "nickname", nullable = false)
     val nickname: String,
 
-    @Column(name = "profile_image")
+    @Column(name = "profile_image", nullable = false)
     val profileImage: Int,
 
-    @Column(name = "email")
+    @Column(name = "email", nullable = false)
     val email: String
 ) : BaseEntity() {
     fun toDomain(): User {

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserRepository.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserRepository.kt
@@ -1,0 +1,11 @@
+package com.mashup.moit.domain.user
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserRepository : JpaRepository<UserEntity, Long> {
+
+    fun findByProviderUniqueKey(providerUniqueKey: String): UserEntity?
+    
+}

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserService.kt
@@ -1,0 +1,21 @@
+package com.mashup.moit.domain.user
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class UserService(
+    private val userRepository: UserRepository
+) {
+
+    @Transactional
+    fun createUser(user: UserEntity): User {
+        return userRepository.save(user).toDomain()
+    }
+
+    fun findByProviderUniqueKey(providerUniqueKey: String): User? {
+        return userRepository.findByProviderUniqueKey(providerUniqueKey)?.toDomain()
+    }
+
+}

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/user/UserService.kt
@@ -10,8 +10,8 @@ class UserService(
 ) {
 
     @Transactional
-    fun createUser(user: UserEntity): User {
-        return userRepository.save(user).toDomain()
+    fun createUser(providerUniqueKey: String, nickname: String, profileImage: Int, email: String): User {
+        return userRepository.save(UserEntity(providerUniqueKey, nickname, profileImage, email)).toDomain()
     }
 
     fun findByProviderUniqueKey(providerUniqueKey: String): User? {


### PR DESCRIPTION
로그인 및 회원가입 로직 구체화
- User entity, data class 구체화
- Token에서 User 사용
- JWT Token 구성변경 (sub, aud, ...)
- JWT Filter Login 구체화
- authN/authZ exception Handling

---

다음 PR
- Authorization 구현 (Authority 구현 필요)
- defaultSuccessUrl말고 successHandler 사용해보기
- annotation으로 parameter 받을 수 있도록 구성 (Resolver)
- Auth0 계정 재설정

참고) Squash merge 때문인지, Conflict가 너무 심해서 develop으로부터 Merge 해놓았습니다.
- Conflict 계속발생해서, 머지 전 rebase 또는 merge 수행예정