### PR TITLE
feat: attendance initialize & request

### DIFF
--- a/http/study.http
+++ b/http/study.http
@@ -3,3 +3,22 @@ GET {{moit-api}}/api/v1/study/{{studyId}}/attendance/keyword
 
 ### 스터디 출석 상태 조회
 GET {{moit-api}}/api/v1/study/{{studyId}}/attendance/status
+
+### 스터디 출석 키워드 등록
+POST {{moit-api}}/api/v1/study/{{studyId}}/attendance/keyword/register
+Content-Type: application/json
+
+{
+    "attendanceKeyword": "아자홧팅"
+}
+
+### 스터디 출석 키워드 인증
+POST {{moit-api}}/api/v1/study/{{studyId}}/attendance/keyword/verify
+Content-Type: application/json
+
+{
+    "attendanceKeyword": "아자홧팅"
+}
+
+### 스터디 출석 초기화
+POST {{moit-api}}/api/v1/study/{{studyId}}/attendance/initialize

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/controller/StudyController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/controller/StudyController.kt
@@ -51,14 +51,24 @@ class StudyController(
     @Operation(summary = "Register Study Keyword API", description = "Study 키워드 등록")
     @PostMapping("/{studyId}/attendance/keyword/register")
     fun registerAttendanceKeyword(@PathVariable studyId: Long, @RequestBody @Valid request: StudyAttendanceKeywordRequest): MoitApiResponse<Unit> {
-        studyFacade.registerAttendanceKeyword(studyId, request)
+        // TODO 인증 개발 완료 후 userId mock 제거
+        studyFacade.registerAttendanceKeyword(7, studyId, request)
         return MoitApiResponse.success()
     }
 
     @Operation(summary = "Verify Study Keyword API", description = "Study 키워드 검증")
-    @PostMapping("/{studyId}/attendance/code/verify")
+    @PostMapping("/{studyId}/attendance/keyword/verify")
     fun verifyAttendanceKeyword(@PathVariable studyId: Long, @RequestBody @Valid request: StudyAttendanceKeywordRequest): MoitApiResponse<Unit> {
-        studyFacade.verifyAttendanceKeyword(studyId, request)
+        // TODO 인증 개발 완료 후 userId mock 제거
+        studyFacade.verifyAttendanceKeyword(7, studyId, request)
+        return MoitApiResponse.success()
+    }
+
+    @Operation(summary = "Initialize Attendance", description = "Study 출석 초기화")
+    @PostMapping("/{studyId}/attendance/initialize")
+    fun initializeAttendance(@PathVariable studyId: Long): MoitApiResponse<Unit> {
+        // TODO 인증 개발 완료 후 userId mock 제거
+        studyFacade.initializeAttendance(studyId)
         return MoitApiResponse.success()
     }
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/facade/StudyFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/facade/StudyFacade.kt
@@ -19,6 +19,13 @@ class StudyFacade(
     private val attendanceService: AttendanceService,
     private val userService: UserService,
 ) {
+    fun getDetails(studyId: Long): StudyDetailsResponse {
+        val study = studyService.findById(studyId)
+        val moit = moitService.getMoitById(study.moitId)
+        val firstAttendanceUser = study.firstAttendanceUserId?.let(userService::findByIdOrNull)
+        return StudyDetailsResponse.of(moit, study, firstAttendanceUser)
+    }
+
     fun getUserAttendanceStatus(studyId: Long): List<StudyUserAttendanceStatusResponse> {
         val attendances = attendanceService.findAttendancesByStudyId(studyId)
         val usersById = userService.findUsersById(attendances.map { it.userId })
@@ -32,22 +39,11 @@ class StudyFacade(
             .let { StudyAttendanceKeywordResponse.of(it) }
     }
 
-    fun getDetails(studyId: Long): StudyDetailsResponse {
-        val study = studyService.findById(studyId)
-        val moit = moitService.getMoitById(study.moitId)
-        val firstAttendanceUser = study.firstAttendanceUserId?.let(userService::findByIdOrNull)
-        return StudyDetailsResponse.of(moit, study, firstAttendanceUser)
-    }
-
     @Transactional
     fun registerAttendanceKeyword(userId: Long, studyId: Long, request: StudyAttendanceKeywordRequest) {
         studyService.registerAttendanceKeyword(studyId, request.attendanceKeyword).also {
             attendanceService.requestAttendance(userId, studyId)
         }
-    }
-
-    fun registerAttendanceKeyword(studyId: Long, request: StudyAttendanceKeywordRequest) {
-        studyService.registerAttendanceKeyword(studyId, request.attendanceKeyword)
     }
 
     @Transactional

--- a/moit-api/src/main/kotlin/com/mashup/moit/study/facade/StudyFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/study/facade/StudyFacade.kt
@@ -9,6 +9,7 @@ import com.mashup.moit.study.controller.dto.StudyAttendanceKeywordResponse
 import com.mashup.moit.study.controller.dto.StudyDetailsResponse
 import com.mashup.moit.study.controller.dto.StudyUserAttendanceStatusResponse
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class StudyFacade(
@@ -37,11 +38,21 @@ class StudyFacade(
         return StudyDetailsResponse.of(moit, study, firstAttendanceUser)
     }
 
-    fun registerAttendanceKeyword(studyId: Long, request: StudyAttendanceKeywordRequest) {
-        studyService.registerAttendanceKeyword(studyId, request.attendanceKeyword)
+    @Transactional
+    fun registerAttendanceKeyword(userId: Long, studyId: Long, request: StudyAttendanceKeywordRequest) {
+        studyService.registerAttendanceKeyword(studyId, request.attendanceKeyword).also {
+            attendanceService.requestAttendance(userId, studyId)
+        }
     }
 
-    fun verifyAttendanceKeyword(studyId: Long, request: StudyAttendanceKeywordRequest) {
-        studyService.verifyAttendanceKeyword(studyId, request.attendanceKeyword)
+    @Transactional
+    fun verifyAttendanceKeyword(userId: Long, studyId: Long, request: StudyAttendanceKeywordRequest) {
+        studyService.verifyAttendanceKeyword(studyId, request.attendanceKeyword).also {
+            attendanceService.requestAttendance(userId, studyId)
+        }
+    }
+
+    fun initializeAttendance(studyId: Long) {
+        attendanceService.initializeAttendance(studyId)
     }
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceEntity.kt
@@ -15,14 +15,14 @@ class AttendanceEntity(
     val studyId: Long,
 
     @Column(name = "user_id", nullable = false)
-    var userId: Long,
+    val userId: Long,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    val status: AttendanceStatus,
+    var status: AttendanceStatus,
 
     @Column(name = "attendance_at")
-    val attendanceAt: LocalDateTime?,
+    var attendanceAt: LocalDateTime?,
 ) : BaseEntity() {
     fun toDomain() = Attendance(
         studyId = studyId,

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceRepository.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceRepository.kt
@@ -5,5 +5,6 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface AttendanceRepository : JpaRepository<AttendanceEntity, Long> {
+    fun findByUserIdAndStudyId(userId: Long, studyId: Long): AttendanceEntity?
     fun findAllByStudyIdOrderByAttendanceAtAsc(studyId: Long): List<AttendanceEntity>
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceService.kt
@@ -32,7 +32,7 @@ class AttendanceService(
     }
 
     @Transactional
-    fun requestAttendance(userId: Long, studyId: Long) {
+    fun requestAttendance(userId: Long, studyId: Long): Attendance {
         val study = studyRepository.findById(studyId).orElseThrow { MoitException.of(MoitExceptionType.NOT_EXIST) }
         val attendance = attendanceRepository.findByUserIdAndStudyId(userId, studyId)
             ?: throw MoitException.of(MoitExceptionType.ATTENDANCE_NOT_STARTED)
@@ -44,10 +44,10 @@ class AttendanceService(
         }
 
         val now = LocalDateTime.now()
-        attendance.apply {
+        return attendance.apply {
             this.status = study.attendanceStatus(now)
             this.attendanceAt = now
-        }
+        }.toDomain()
     }
 
     fun findAttendancesByStudyId(studyId: Long): List<Attendance> {

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceService.kt
@@ -36,6 +36,12 @@ class AttendanceService(
         val study = studyRepository.findById(studyId).orElseThrow { MoitException.of(MoitExceptionType.NOT_EXIST) }
         val attendance = attendanceRepository.findByUserIdAndStudyId(userId, studyId)
             ?: throw MoitException.of(MoitExceptionType.ATTENDANCE_NOT_STARTED)
+        if (attendance.status !== AttendanceStatus.UNDECIDED) {
+            throw MoitException.of(
+                MoitExceptionType.ALREADY_EXIST,
+                "이미 출석하였습니다."
+            )
+        }
 
         val now = LocalDateTime.now()
         attendance.apply {

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceService.kt
@@ -2,7 +2,6 @@ package com.mashup.moit.domain.attendance
 
 import com.mashup.moit.common.exception.MoitException
 import com.mashup.moit.common.exception.MoitExceptionType
-import com.mashup.moit.domain.study.StudyEntity
 import com.mashup.moit.domain.study.StudyRepository
 import com.mashup.moit.domain.usermoit.UserMoitRepository
 import org.springframework.stereotype.Service
@@ -59,13 +58,5 @@ class AttendanceService(
 
     fun existFirstAttendanceByStudyId(studyId: Long): Boolean {
         return attendanceRepository.existsByStudyIdAndStatus(studyId, AttendanceStatus.ATTENDANCE)
-    }
-
-    private fun StudyEntity.attendanceStatus(dateTime: LocalDateTime): AttendanceStatus {
-        return when {
-            dateTime.isBefore(lateAt) -> AttendanceStatus.ATTENDANCE
-            dateTime.isBefore(absenceAt) -> AttendanceStatus.LATE
-            else -> AttendanceStatus.ABSENCE
-        }
     }
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/attendance/AttendanceService.kt
@@ -2,18 +2,60 @@ package com.mashup.moit.domain.attendance
 
 import com.mashup.moit.common.exception.MoitException
 import com.mashup.moit.common.exception.MoitExceptionType
+import com.mashup.moit.domain.study.StudyEntity
+import com.mashup.moit.domain.study.StudyRepository
+import com.mashup.moit.domain.usermoit.UserMoitRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
 class AttendanceService(
     private val attendanceRepository: AttendanceRepository,
+    private val studyRepository: StudyRepository,
+    private val userMoitRepository: UserMoitRepository,
 ) {
+    @Transactional
+    fun initializeAttendance(studyId: Long) {
+        val study = studyRepository.findById(studyId).orElseThrow { MoitException.of(MoitExceptionType.NOT_EXIST) }
+        val userMoits = userMoitRepository.findAllByMoitId(study.moitId)
+
+        userMoits.map {
+            AttendanceEntity(
+                studyId = studyId,
+                userId = it.userId,
+                status = AttendanceStatus.UNDECIDED,
+                attendanceAt = null,
+            )
+        }.let { attendanceRepository.saveAll(it) }
+    }
+
+    @Transactional
+    fun requestAttendance(userId: Long, studyId: Long) {
+        val study = studyRepository.findById(studyId).orElseThrow { MoitException.of(MoitExceptionType.NOT_EXIST) }
+        val attendance = attendanceRepository.findByUserIdAndStudyId(userId, studyId)
+            ?: throw MoitException.of(MoitExceptionType.ATTENDANCE_NOT_STARTED)
+
+        val now = LocalDateTime.now()
+        attendance.apply {
+            this.status = study.attendanceStatus(now)
+            this.attendanceAt = now
+        }
+    }
+
     fun findAttendancesByStudyId(studyId: Long): List<Attendance> {
         return attendanceRepository.findAllByStudyIdOrderByAttendanceAtAsc(studyId)
             .takeIf { it.isNotEmpty() }
             ?.map { it.toDomain() }
             ?: throw MoitException.of(MoitExceptionType.ATTENDANCE_NOT_STARTED)
+    }
+
+    private fun StudyEntity.attendanceStatus(dateTime: LocalDateTime): AttendanceStatus {
+        return when {
+            dateTime.isBefore(lateAt) -> AttendanceStatus.ATTENDANCE
+            dateTime.isBefore(absenceAt) -> AttendanceStatus.LATE
+            else -> AttendanceStatus.ABSENCE
+        }
     }
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyEntity.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/study/StudyEntity.kt
@@ -1,5 +1,6 @@
 package com.mashup.moit.domain.study
 
+import com.mashup.moit.domain.attendance.AttendanceStatus
 import com.mashup.moit.domain.common.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -47,4 +48,12 @@ class StudyEntity(
         absenceAt = absenceAt,
         firstAttendanceUserId = firstAttendanceUserId,
     )
+
+    fun attendanceStatus(dateTime: LocalDateTime): AttendanceStatus {
+        return when {
+            dateTime.isBefore(lateAt) -> AttendanceStatus.ATTENDANCE
+            dateTime.isBefore(absenceAt) -> AttendanceStatus.LATE
+            else -> AttendanceStatus.ABSENCE
+        }
+    }
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/usermoit/UserMoitRepository.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/usermoit/UserMoitRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface UserMoitRepository : JpaRepository<UserMoitEntity, Long> {
     fun existsByUserIdAndMoitId(userId: Long, moitId: Long): Boolean
     fun findMasterByMoitIdAndRole(moitId: Long, role: UserMoitRole): UserMoitEntity?
+    fun findAllByMoitId(moitId: Long): List<UserMoitEntity>
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/usermoit/UserMoitRepository.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/usermoit/UserMoitRepository.kt
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserMoitRepository : JpaRepository<UserMoitEntity, Long> {
     fun existsByUserIdAndMoitId(userId: Long, moitId: Long): Boolean
-    fun findMasterByMoitIdAndRole(moitId: Long, role: UserMoitRole): UserMoitEntity?
+    fun findByMoitIdAndRole(moitId: Long, role: UserMoitRole): UserMoitEntity?
     fun findAllByMoitId(moitId: Long): List<UserMoitEntity>
 }

--- a/moit-domain/src/main/kotlin/com/mashup/moit/domain/usermoit/UserMoitService.kt
+++ b/moit-domain/src/main/kotlin/com/mashup/moit/domain/usermoit/UserMoitService.kt
@@ -30,7 +30,7 @@ class UserMoitService(
     }
 
     fun findMasterUserByMoitId(moitId: Long): UserMoit {
-        return userMoitRepository.findMasterByMoitIdAndRole(moitId, UserMoitRole.MASTER)?.toDomain()
+        return userMoitRepository.findByMoitIdAndRole(moitId, UserMoitRole.MASTER)?.toDomain()
             ?: throw MoitException.of(MoitExceptionType.NOT_EXIST)
     }
 }


### PR DESCRIPTION
- 출석을 미결 상태로 초기화 (initialize) API 개발
  - 일단은 API 호출을 통해 수동으로 처리하고 후속 PR 에서 자동으로 주기적으로 실행되도록 개선할 예정입니다.
- 키워드 등록, 인증 API 에서 출석 처리를 하고 있지 않아 출석 처리 하도록 개발
  - 키워드 등록 API는 /attendance/keyword/register, 인증 API 는 /attendance/code/verify 여서 keyword 로 통일했습니다.