### PR TITLE
feat: 미회원가입 유저가 로그인 시도 시 정보를 헤더로 반환

### DIFF
--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/AuthController.kt
@@ -3,7 +3,7 @@ package com.mashup.moit.controller
 import com.mashup.moit.controller.dto.UserRegisterRequest
 import com.mashup.moit.facade.UserFacade
 import com.mashup.moit.security.authentication.UserInfo
-import com.mashup.moit.security.authentication.toBeforeSignUpInfo
+import com.mashup.moit.security.authentication.toHttpHeader
 import com.mashup.moit.security.jwt.JwtTokenSupporter
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -35,7 +35,9 @@ class AuthController(
     @GetMapping("/sign-in/success")
     fun signInSuccess(@AuthenticationPrincipal oidcUser: OidcUser): ResponseEntity<Any> {
         val user = userFacade.findByProviderUniqueKey(oidcUser)
-            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(oidcUser.toBeforeSignUpInfo())
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .headers(oidcUser.toHttpHeader())
+                .build()
 
         val jwtToken = jwtTokenSupporter.createToken(UserInfo.from(user))
         return ResponseEntity.ok()

--- a/moit-api/src/main/kotlin/com/mashup/moit/security/authentication/MoitUser.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/security/authentication/MoitUser.kt
@@ -2,7 +2,7 @@ package com.mashup.moit.security.authentication
 
 import com.mashup.moit.common.exception.MoitException
 import com.mashup.moit.common.exception.MoitExceptionType
-import com.mashup.moit.controller.dto.UserBeforeSignUpInfoResponse
+import org.springframework.http.HttpHeaders
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
@@ -12,6 +12,10 @@ private const val PROVIDER_SPLIT_DELIMITER = "|"
 private const val CLAIM_SUB_KEY = "sub"
 private const val CLAIM_EMAIL_KEY = "email"
 private const val CLAIM_NICKNAME_KEY = "nickname"
+
+private const val EMAIL_HEADER_KEY = "X-MOIT-USER-EMAIL"
+private const val NICKNAME_HEADER_KEY = "X-MOIT-USER-NICKNAME"
+private const val PROVIDER_HEADER_KEY = "X-MOIT-USER-PROVIDER"
 
 data class MoitUser(val userInfo: UserInfo) : OAuth2User {
     private val authorities: Collection<GrantedAuthority>
@@ -55,9 +59,14 @@ fun OidcUser.getProviderUniqueKey(): String {
     return "$authProvider${PROVIDER_SPLIT_DELIMITER}$email"
 }
 
-fun OidcUser.toBeforeSignUpInfo(): UserBeforeSignUpInfoResponse {
+fun OidcUser.toHttpHeader(): HttpHeaders {
     val email = this.getClaimAsString(CLAIM_EMAIL_KEY)
     val nickname = this.getClaimAsString(CLAIM_NICKNAME_KEY)
     val authProviderUniqueKey = this.getProviderUniqueKey()
-    return UserBeforeSignUpInfoResponse(authProviderUniqueKey, nickname, email)
+    return HttpHeaders().apply {
+        set(EMAIL_HEADER_KEY, email)
+        set(NICKNAME_HEADER_KEY, nickname)
+        set(PROVIDER_HEADER_KEY, authProviderUniqueKey)
+    }
+
 }


### PR DESCRIPTION
iOS 요청

회원가입되지 않은 유저의 로그인 요청 시, OAuth로부터 받은 유저정보를 헤더로 반환

- `X-MOIT-USER-EMAIL`
- `X-MOIT-USER-NICKNAME`
- `X-MOIT-USER-PROVIDER`
