### PR TITLE
feat: use kafka to process banner update asynchronously

### DIFF
--- a/moit-api/src/main/kotlin/com/mashup/moit/facade/FineFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/facade/FineFacade.kt
@@ -5,13 +5,13 @@ import com.mashup.moit.common.exception.MoitExceptionType
 import com.mashup.moit.controller.fine.dto.FineListResponse
 import com.mashup.moit.controller.fine.dto.FineResponse
 import com.mashup.moit.controller.fine.dto.FineResponseForListView
-import com.mashup.moit.domain.banner.BannerService
-import com.mashup.moit.domain.banner.update.MoitUnapprovedFineExistBannerUpdateRequest
 import com.mashup.moit.domain.fine.FineService
 import com.mashup.moit.domain.study.StudyService
 import com.mashup.moit.domain.user.UserService
 import com.mashup.moit.domain.usermoit.UserMoitService
 import com.mashup.moit.infra.aws.s3.S3Service
+import com.mashup.moit.infra.event.EventProducer
+import com.mashup.moit.infra.event.FineApproveEvent
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 
@@ -21,7 +21,7 @@ class FineFacade(
     private val studyService: StudyService,
     private val userService: UserService,
     private val userMoitService: UserMoitService,
-    private val bannerService: BannerService,
+    private val eventProducer: EventProducer,
     private val s3Service: S3Service,
 ) {
 
@@ -58,8 +58,7 @@ class FineFacade(
 
         fineService.updateFineApproveStatus(fineId, confirmFine)
         if (confirmFine) {
-            // TODO Kafka 머지 후 비동기로 전환 (FineConfirmEvent)
-            bannerService.update(MoitUnapprovedFineExistBannerUpdateRequest(fineId))
+            eventProducer.produce(FineApproveEvent(fineId = fineId))
         }
     }
 

--- a/moit-api/src/main/kotlin/com/mashup/moit/facade/StudyFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/facade/StudyFacade.kt
@@ -10,7 +10,7 @@ import com.mashup.moit.domain.moit.MoitService
 import com.mashup.moit.domain.study.StudyService
 import com.mashup.moit.domain.user.UserService
 import com.mashup.moit.infra.event.EventProducer
-import com.mashup.moit.infra.event.FineCreateRequestEvent
+import com.mashup.moit.infra.event.StudyAttendanceEvent
 import com.mashup.moit.infra.event.StudyInitializeEvent
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -47,7 +47,7 @@ class StudyFacade(
     fun registerAttendanceKeyword(userId: Long, studyId: Long, request: StudyAttendanceKeywordRequest) {
         studyService.registerAttendanceKeyword(studyId, request.attendanceKeyword).also {
             val attendance = attendanceService.requestAttendance(userId, studyId)
-            eventProducer.produce(FineCreateRequestEvent(attendanceId = attendance.id, moitId = it.moitId))
+            eventProducer.produce(StudyAttendanceEvent(attendanceId = attendance.id, moitId = it.moitId))
         }
     }
 
@@ -55,7 +55,7 @@ class StudyFacade(
     fun verifyAttendanceKeyword(userId: Long, studyId: Long, request: StudyAttendanceKeywordRequest) {
         studyService.verifyAttendanceKeyword(studyId, request.attendanceKeyword).also {
             val attendance = attendanceService.requestAttendance(userId, studyId)
-            eventProducer.produce(FineCreateRequestEvent(attendanceId = attendance.id, moitId = it.moitId))
+            eventProducer.produce(StudyAttendanceEvent(attendanceId = attendance.id, moitId = it.moitId))
         }
     }
 

--- a/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEvent.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEvent.kt
@@ -6,12 +6,30 @@ fun interface MoitEvent {
 
 data class MoitCreateEvent(val moitId: Long) : MoitEvent {
     override fun getTopic(): String {
-        return MOIT_CREATE_TOPIC
+        return KafkaEventTopic.MOIT_CREATE
     }
 }
 
-data class FineCreateEvent(val attendanceId: Long, val moitId: Long) : MoitEvent {
+data class FineCreateRequestEvent(val attendanceId: Long, val moitId: Long) : MoitEvent {
     override fun getTopic(): String {
-        return FINE_CREATE_TOPIC
+        return KafkaEventTopic.FINE_CREATE_REQUEST
+    }
+}
+
+data class StudyInitializeEvent(val studyId: Long) : MoitEvent {
+    override fun getTopic(): String {
+        return KafkaEventTopic.STUDY_INITIALIZE
+    }
+}
+
+data class FineCreateEvent(val fineId: Long) : MoitEvent {
+    override fun getTopic(): String {
+        return KafkaEventTopic.FINE_CREATE
+    }
+}
+
+data class FineApproveEvent(val fineId: Long) : MoitEvent {
+    override fun getTopic(): String {
+        return KafkaEventTopic.FINE_APPROVE
     }
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEvent.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEvent.kt
@@ -10,9 +10,9 @@ data class MoitCreateEvent(val moitId: Long) : MoitEvent {
     }
 }
 
-data class FineCreateRequestEvent(val attendanceId: Long, val moitId: Long) : MoitEvent {
+data class StudyAttendanceEvent(val attendanceId: Long, val moitId: Long) : MoitEvent {
     override fun getTopic(): String {
-        return KafkaEventTopic.FINE_CREATE_REQUEST
+        return KafkaEventTopic.STUDY_ATTENDANCE
     }
 }
 

--- a/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEventTopic.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEventTopic.kt
@@ -1,4 +1,16 @@
 package com.mashup.moit.infra.event
 
-const val MOIT_CREATE_TOPIC = "moit_create"
-const val FINE_CREATE_TOPIC = "fine_create"
+object KafkaEventTopic {
+    const val MOIT_CREATE = "moit_create"
+    const val FINE_CREATE_REQUEST = "fine_create_request"
+    const val STUDY_INITIALIZE = "study_initialize"
+    const val FINE_CREATE = "fine_create"
+    const val FINE_APPROVE = "fine_approve"
+}
+
+object KafkaConsumerGroup {
+    const val MOIT_CREATE_STUDY_CREATE = "moit_create_study_create"
+    const val STUDY_INITIALIZE_BANNER_UPDATE = "study_initialize_banner_update"
+    const val FINE_CREATE_BANNER_UPDATE = "fine_create_banner_update"
+    const val FINE_APPROVE_BANNER_UPDATE = "fine_approve_banner_update"
+}

--- a/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEventTopic.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEventTopic.kt
@@ -2,8 +2,8 @@ package com.mashup.moit.infra.event
 
 object KafkaEventTopic {
     const val MOIT_CREATE = "moit_create"
-    const val FINE_CREATE_REQUEST = "fine_create_request"
     const val STUDY_INITIALIZE = "study_initialize"
+    const val STUDY_ATTENDANCE = "study_attendance"
     const val FINE_CREATE = "fine_create"
     const val FINE_APPROVE = "fine_approve"
 }
@@ -11,6 +11,7 @@ object KafkaEventTopic {
 object KafkaConsumerGroup {
     const val MOIT_CREATE_STUDY_CREATE = "moit_create_study_create"
     const val STUDY_INITIALIZE_BANNER_UPDATE = "study_initialize_banner_update"
+    const val STUDY_ATTENDANCE_FINE_CREATE = "study_attendance_fine_create"
     const val FINE_CREATE_BANNER_UPDATE = "fine_create_banner_update"
     const val FINE_APPROVE_BANNER_UPDATE = "fine_approve_banner_update"
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/infra/event/kafka/KafkaConsumer.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/infra/event/kafka/KafkaConsumer.kt
@@ -1,11 +1,18 @@
 package com.mashup.moit.infra.event.kafka
 
+import com.mashup.moit.domain.banner.BannerService
+import com.mashup.moit.domain.banner.update.MoitUnapprovedFineExistBannerUpdateRequest
+import com.mashup.moit.domain.banner.update.StudyAttendanceStartBannerUpdateRequest
 import com.mashup.moit.domain.fine.FineService
 import com.mashup.moit.domain.study.StudyService
-import com.mashup.moit.infra.event.FINE_CREATE_TOPIC
+import com.mashup.moit.infra.event.EventProducer
+import com.mashup.moit.infra.event.FineApproveEvent
 import com.mashup.moit.infra.event.FineCreateEvent
-import com.mashup.moit.infra.event.MOIT_CREATE_TOPIC
+import com.mashup.moit.infra.event.FineCreateRequestEvent
+import com.mashup.moit.infra.event.KafkaConsumerGroup
+import com.mashup.moit.infra.event.KafkaEventTopic
 import com.mashup.moit.infra.event.MoitCreateEvent
+import com.mashup.moit.infra.event.StudyInitializeEvent
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
@@ -15,19 +22,52 @@ import org.springframework.stereotype.Component
 class KafkaConsumer(
     private val studyService: StudyService,
     private val fineService: FineService,
+    private val bannerService: BannerService,
+    private val eventProducer: EventProducer,
 ) {
     private val log: Logger = LoggerFactory.getLogger(KafkaConsumer::class.java)
 
-    @KafkaListener(topics = [MOIT_CREATE_TOPIC])
+    @KafkaListener(
+        topics = [KafkaEventTopic.MOIT_CREATE],
+        groupId = KafkaConsumerGroup.MOIT_CREATE_STUDY_CREATE,
+    )
     fun consumeMoitCreateEvent(event: MoitCreateEvent) {
         log.debug("consumeMoitCreateEvent called: {}", event)
         studyService.createStudies(event.moitId)
     }
 
-    @KafkaListener(topics = [FINE_CREATE_TOPIC])
-    fun consumeFineCreateEvent(event: FineCreateEvent) {
+    @KafkaListener(topics = [KafkaEventTopic.FINE_CREATE_REQUEST])
+    fun consumeFineCreateEvent(event: FineCreateRequestEvent) {
         log.debug("consumeFineCreateEvent called: {}", event)
-        fineService.create(event.attendanceId, event.moitId)
+        fineService.create(event.attendanceId, event.moitId)?.also {
+            eventProducer.produce(FineCreateEvent(fineId = it.id))
+        }
     }
 
+    @KafkaListener(
+        topics = [KafkaEventTopic.STUDY_INITIALIZE],
+        groupId = KafkaConsumerGroup.STUDY_INITIALIZE_BANNER_UPDATE,
+    )
+    fun consumeStudyInitializeEvent(event: StudyInitializeEvent) {
+        log.debug("consumeStudyInitializeEvent called: {}", event)
+        bannerService.update(StudyAttendanceStartBannerUpdateRequest(event.studyId))
+    }
+
+    @KafkaListener(
+        topics = [KafkaEventTopic.FINE_CREATE],
+        groupId = KafkaConsumerGroup.FINE_CREATE_BANNER_UPDATE,
+    )
+    fun consumeFineCreateEvent(event: FineCreateEvent) {
+        log.debug("consumeFineCreateEvent called: {}", event)
+        bannerService.update(MoitUnapprovedFineExistBannerUpdateRequest(event.fineId))
+    }
+
+    @KafkaListener(
+        topics = [KafkaEventTopic.FINE_APPROVE],
+        groupId = KafkaConsumerGroup.FINE_APPROVE_BANNER_UPDATE,
+    )
+    fun consumeFineApproveEvent(event: FineApproveEvent) {
+        log.debug("consumeFineApproveEvent called: {}", event)
+        bannerService.update(MoitUnapprovedFineExistBannerUpdateRequest(event.fineId))
+    }
 }


### PR DESCRIPTION
- 배너 업데이트를 Kafka 메세지 기반 비동기로 처리하도록 수정
- 기존에 FineCreateEvent 를 [여기](https://github.com/mash-up-kr/MOIT-backend/pull/93#discussion_r1271474309) 에서 논의한 것과 같이 FineCreateRequestEvent 로 수정
- KafkaListener 에 컨슈머 그룹 지정