### PR TITLE
feat: 로그인 반환 데이터 변경

### DIFF
--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/user/AuthController.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/user/AuthController.kt
@@ -1,6 +1,8 @@
 package com.mashup.moit.controller.user
 
-import com.mashup.moit.controller.dto.UserRegisterRequest
+import com.mashup.moit.common.MoitApiResponse
+import com.mashup.moit.controller.user.dto.TokenResponse
+import com.mashup.moit.controller.user.dto.UserRegisterRequest
 import com.mashup.moit.facade.UserFacade
 import com.mashup.moit.security.authentication.UserInfo
 import com.mashup.moit.security.authentication.toHttpHeader
@@ -37,16 +39,18 @@ class AuthController(
 
     @Operation(summary = "로그인 성공 (리다이렉트용)", description = "로그인 성공 API - 서버 단 Redirect 용")
     @GetMapping("/sign-in/success")
-    fun signInSuccess(@AuthenticationPrincipal oidcUser: OidcUser): ResponseEntity<Any> {
+    fun signInSuccess(@AuthenticationPrincipal oidcUser: OidcUser): ResponseEntity<MoitApiResponse<Any?>> {
         val user = userFacade.findByProviderUniqueKey(oidcUser)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .headers(oidcUser.toHttpHeader())
-                .build()
-
+                .body(MoitApiResponse.success(null))
+        
         val jwtToken = jwtTokenSupporter.createToken(UserInfo.from(user))
+        
         return ResponseEntity.ok()
-            .header(HttpHeaders.AUTHORIZATION, "${JwtTokenSupporter.BEARER_TOKEN_PREFIX} $jwtToken")
-            .build()
+            .body(MoitApiResponse.success(
+                TokenResponse("${JwtTokenSupporter.BEARER_TOKEN_PREFIX} $jwtToken"))
+            )
     }
 
     @Operation(summary = "회원가입", description = "회원가입 API")

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/user/dto/TokenResponse.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/user/dto/TokenResponse.kt
@@ -1,0 +1,3 @@
+package com.mashup.moit.controller.user.dto
+
+data class TokenResponse(val token: String)

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/user/dto/UserBeforeSignUpInfoResponse.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/user/dto/UserBeforeSignUpInfoResponse.kt
@@ -1,4 +1,4 @@
-package com.mashup.moit.controller.dto
+package com.mashup.moit.controller.user.dto
 
 data class UserBeforeSignUpInfoResponse(
     val providerUniqueKey: String,

--- a/moit-api/src/main/kotlin/com/mashup/moit/controller/user/dto/UserRegisterRequest.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/controller/user/dto/UserRegisterRequest.kt
@@ -1,4 +1,4 @@
-package com.mashup.moit.controller.dto
+package com.mashup.moit.controller.user.dto
 
 data class UserRegisterRequest(
     val providerUniqueKey: String,

--- a/moit-api/src/main/kotlin/com/mashup/moit/facade/UserFacade.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/facade/UserFacade.kt
@@ -2,7 +2,7 @@ package com.mashup.moit.facade
 
 import com.mashup.moit.common.exception.MoitException
 import com.mashup.moit.common.exception.MoitExceptionType
-import com.mashup.moit.controller.dto.UserRegisterRequest
+import com.mashup.moit.controller.user.dto.UserRegisterRequest
 import com.mashup.moit.domain.moit.MoitService
 import com.mashup.moit.domain.user.User
 import com.mashup.moit.domain.user.UserService


### PR DESCRIPTION
- 헤더에 전달하던 토큰 데이터를 body에 담아 반환하도록 수정
- user response dto의 패키지를 user 패키지 하위로 변경
