### PR TITLE
chore: use X-Forwarded header

### DIFF
--- a/moit-api/src/main/resources/application.yml
+++ b/moit-api/src/main/resources/application.yml
@@ -116,3 +116,5 @@ cloud:
 fcm:
   certification: firebase/moit-firebase-adminsdk.json
 
+server:
+  forward-headers-strategy: FRAMEWORK


### PR DESCRIPTION
Swagger를 Reverse proxy 환경에서도 사용하기 위하여 `server.forward-headers-strategy: FRAMEWORK`을 추가했습니다.

- ref: https://binux.tistory.com/161