### PR TITLE
update: kafka notifcation topic unification

### DIFF
--- a/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEvent.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEvent.kt
@@ -48,20 +48,25 @@ data class FineApproveEvent(val fineId: Long) : MoitEvent {
     }
 }
 
-data class StudyAttendanceStartNotificationPushEvent(val studyIdWithMoitIds: Set<Pair<Long, Long>>, val flushAt: LocalDateTime) : MoitEvent {
-    override fun getTopic(): String {
-        return KafkaEventTopic.STUDY_ATTENDANCE_START_NOTIFICATION
-    }
-}
+data class StudyAttendanceStartNotificationPushEvent(
+    val studyIdWithMoitIds: Set<Pair<Long, Long>>,
+    override val flushAt: LocalDateTime
+) : NotificationPushEvent(flushAt)
 
-data class RemindFineNotificationPushEvent(val fineIds: Set<Long>, val flushAt: LocalDateTime) : MoitEvent {
+data class RemindFineNotificationPushEvent(
+    val fineIds: Set<Long>,
+    override val flushAt: LocalDateTime
+) : NotificationPushEvent(flushAt)
+
+data class ScheduledStudyNotificationPushEvent(
+    val studyIdWithMoitIds: Set<Pair<Long, Long>>,
+    override val flushAt: LocalDateTime
+) : NotificationPushEvent(flushAt)
+
+abstract class NotificationPushEvent(
+    open val flushAt: LocalDateTime
+) : MoitEvent {
     override fun getTopic(): String {
-        return KafkaEventTopic.REMIND_FINE_NOTIFICATION
-    }
-}
-    
-data class ScheduledStudyNotificationPushEvent(val studyIdWithMoitIds: Set<Pair<Long, Long>>, val flushAt: LocalDateTime) : MoitEvent {
-    override fun getTopic(): String {
-        return KafkaEventTopic.STUDY_ATTENDANCE_START_NOTIFICATION
+        return KafkaEventTopic.NOTIFICATION
     }
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEventTopic.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/infra/event/MoitEventTopic.kt
@@ -5,12 +5,10 @@ object KafkaEventTopic {
     const val STUDY_INITIALIZE = "study_initialize"
     const val STUDY_ATTENDANCE = "study_attendance"
     const val STUDY_ATTENDANCE_BULK = "study_attendance_bulk"
-    const val STUDY_ATTENDANCE_START_NOTIFICATION = "study_attendance_start_notification"
-    const val STUDY_SCHEDULED_NOTIFICATION = "study_scheduled_notification"
     const val FINE_CREATE = "fine_create"
     const val FINE_CREATE_BULK = "fine_create_bulk"
     const val FINE_APPROVE = "fine_approve"
-    const val REMIND_FINE_NOTIFICATION = "remind_fine_notification"
+    const val NOTIFICATION = "notification"
 }
 
 object KafkaConsumerGroup {
@@ -18,10 +16,8 @@ object KafkaConsumerGroup {
     const val STUDY_INITIALIZE_BANNER_UPDATE = "study_initialize_banner_update"
     const val STUDY_ATTENDANCE_FINE_CREATE = "study_attendance_fine_create"
     const val STUDY_ATTENDANCE_FINE_CREATE_BULK = "study_attendance_fine_create_bulk"
-    const val STUDY_ATTENDANCE_START_NOTIFICATION_CREATE = "study_attendance_start_notification_create"
-    const val STUDY_SCHEDULED_NOTIFICATION_CREATE = "study_scheduled_notification_create"
     const val FINE_CREATE_BANNER_UPDATE = "fine_create_banner_update"
     const val FINE_CREATE_BANNER_UPDATE_BULK = "fine_create_banner_update_bulk"
     const val FINE_APPROVE_BANNER_UPDATE = "fine_approve_banner_update"
-    const val REMIND_FINE_NOTIFICATION_CREATE = "remind_fine_notification_create"
+    const val NOTIFICATION_CREATE = "notification_create"
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/infra/event/kafka/KafkaConsumer.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/infra/event/kafka/KafkaConsumer.kt
@@ -15,7 +15,7 @@ import com.mashup.moit.infra.event.FineCreateEventBulk
 import com.mashup.moit.infra.event.KafkaConsumerGroup
 import com.mashup.moit.infra.event.KafkaEventTopic
 import com.mashup.moit.infra.event.MoitCreateEvent
-
+import com.mashup.moit.infra.event.NotificationPushEvent
 import com.mashup.moit.infra.event.RemindFineNotificationPushEvent
 import com.mashup.moit.infra.event.ScheduledStudyNotificationPushEvent
 import com.mashup.moit.infra.event.StudyAttendanceEvent
@@ -109,29 +109,15 @@ class KafkaConsumer(
     }
 
     @KafkaListener(
-        topics = [KafkaEventTopic.STUDY_ATTENDANCE_START_NOTIFICATION],
-        groupId = KafkaConsumerGroup.STUDY_ATTENDANCE_START_NOTIFICATION_CREATE,
+        topics = [KafkaEventTopic.NOTIFICATION],
+        groupId = KafkaConsumerGroup.NOTIFICATION_CREATE,
     )
-    fun consumeStudyAttendanceStartNotificationPushEvent(event: StudyAttendanceStartNotificationPushEvent) {
-        log.debug("consumeStudyAttendanceStartNotificationPushEvent called: {}", event)
-        notificationService.save(AttendanceStartNotificationEvent(event.studyIdWithMoitIds, event.flushAt))
-    }
-
-    @KafkaListener(
-        topics = [KafkaEventTopic.REMIND_FINE_NOTIFICATION],
-        groupId = KafkaConsumerGroup.REMIND_FINE_NOTIFICATION_CREATE,
-    )
-    fun consumeRemindFineNotificationPushEvent(event: RemindFineNotificationPushEvent) {
-        log.debug("consumeRemindFineNotificationPushEvent called: {}", event)
-        notificationService.save(RemindFineNotificationEvent(event.fineIds, event.flushAt))
-    }
-
-    @KafkaListener(
-        topics = [KafkaEventTopic.STUDY_SCHEDULED_NOTIFICATION],
-        groupId = KafkaConsumerGroup.STUDY_SCHEDULED_NOTIFICATION_CREATE,
-    )
-    fun consumeScheduledStudyNotificationPushEvent(event: ScheduledStudyNotificationPushEvent) {
-        log.debug("consumeScheduledStudyNotificationPushEvent called: {}", event)
-        notificationService.save(AttendanceStartNotificationEvent(event.studyIdWithMoitIds, event.flushAt))
+    fun consumeNotificationPushEvent(event: NotificationPushEvent) {
+        log.info("NotificationPushEvent called: {}", event)
+        when (event) {
+            is StudyAttendanceStartNotificationPushEvent -> notificationService.save(AttendanceStartNotificationEvent(event.studyIdWithMoitIds, event.flushAt))
+            is RemindFineNotificationPushEvent -> notificationService.save(RemindFineNotificationEvent(event.fineIds, event.flushAt))
+            is ScheduledStudyNotificationPushEvent -> notificationService.save(AttendanceStartNotificationEvent(event.studyIdWithMoitIds, event.flushAt))
+        }
     }
 }

--- a/moit-api/src/main/kotlin/com/mashup/moit/scheduler/NotiPushScheduler.kt
+++ b/moit-api/src/main/kotlin/com/mashup/moit/scheduler/NotiPushScheduler.kt
@@ -49,7 +49,7 @@ class NotiPushScheduler(
     
     @Scheduled(cron = "0 */5 * * * *")
     @Async("pushSchedulerExecutor")
-    fun pushScheduledStudy10AMRemindNotification() {
+    fun pushScheduledStudyRemindNotification() {
         val studies = studyService.findNotPushedStudies(LocalDateTime.now())
 
         val studyMoitMap = studies.associateWith { study ->


### PR DESCRIPTION
upstash topic or partition 이 최대 10개까지가 무료라 notification topic 을 하나로 단일화하였습니다 

produce 시에 부모 클래스로 보내고 consume/deserialize 에서 분류 후 동일 로직 처리합니다. 
(@KimDoubleB topic 변경 부탁드립니다 _ _  ) 